### PR TITLE
Fix JSON String quoting in example of conversions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ type = "pug"
 In JSON land, that would give you the following structure.
 
 ```json
-{ 'key': { 'tater': { 'type': 'pug' } } }
+{ "key": { "tater": { "type": "pug" } } }
 ```
 
 You don't need to specify all the superkeys if you don't want to. TOML knows how


### PR DESCRIPTION
Hey there - The example JSON document of an equivelant to TOML uses incorrect string quoting (See http://www.json.org/ - only `"` is a valid string quotation mark).
