### PR TITLE
Be explicit about not mixing data types

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ by commas. No, you can't mix data types, that's stupid.
 [ 1, 2, 3 ]
 [ "red", "yellow", "green" ]
 [ [ 1, 2 ], [3, 4, 5] ]
+[ [ 1, 2 ], ["a", "b", "c"] ] # Nope. Not cool.
 
 ```
 


### PR DESCRIPTION
It wasn't clear if you can have an array of arrays where the contents of the nested arrays are different types like 

``` toml
[ [ 1, 2 ], ["a", "b", "c"] ]
```

I assume mixed types like this are not allowed, but it may be best to explicitly say so.
