### PR TITLE
The YAML spec is in fact not 600 pages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ But why?
 --------
 
 Because we need a decent human readable format that maps to a hash and the YAML
-spec is like 600 pages long and gives me rage. No, JSON doesn't count. You know
+spec is like 80 pages long and gives me rage. No, JSON doesn't count. You know
 why.
 
 Oh god, you're right


### PR DESCRIPTION
It's still bad, but that's got very little to do with its length.
