### PR TITLE
Allow trailing commas in arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,12 @@ Elements are separated by commas. No, you can't mix data types, that's stupid.
 ```
 
 Arrays can also be multiline. So in addition to ignoring whitespace, arrays also
-ignore newlines between the brackets.
+ignore newlines between the brackets. You can put a comma at the end, TOML don't 
+care.
 
 ```toml
 key = [
-  1, 2, 3
+  1, 2, 3,
 ]
 ```
 


### PR DESCRIPTION
A configuration language should allow a trailing comma at the end of an array. The intent is unambiguous, since arrays only contain primitives.

This lets you comment elements of an array in or out:

```
plugins = [
  "hemiconducer",
  "defremulator",
  #  "carbozaxor"
]
```

One of the infuriating things about JSON as a config language is that it will explode on that array, because of the trailing comma.
