### PR TITLE
Python Parser for TOML

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,5 +238,6 @@ Implementations
 - node.js - https://github.com/aaronblohowiak/toml
 - Ruby (@jm) - https://github.com/jm/toml (toml gem)
 - Ruby (@dirk) - https://github.com/dirk/toml-ruby (toml-ruby gem)
-- Python - https://github.com/uiri/toml
+- Python (@f03lipe) - https://github.com/f03lipe/toml-python
+- Python (@uiri) - https://github.com/uiri/toml
 - C#/.NET - https://github.com/rossipedia/toml-net


### PR DESCRIPTION
A python parser for TOML added to the links.
