### PR TITLE
Add a Ruby parser gem using Citrus

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,5 +238,6 @@ Implementations
 - node.js - https://github.com/aaronblohowiak/toml
 - Ruby (@jm) - https://github.com/jm/toml (toml gem)
 - Ruby (@dirk) - https://github.com/dirk/toml-ruby (toml-ruby gem)
+- Ruby (@eMancu) - https://github.com/eMancu/toml_parser-ruby (toml_parser-ruby gem)
 - Python - https://github.com/uiri/toml
 - C#/.NET - https://github.com/rossipedia/toml-net


### PR DESCRIPTION
Instead using a huge ruby file to parse TOML, I went for a proper library to do it like [Citrus](http://mjijackson.com/citrus/index.html)
