### PR TITLE
Fixed a grammar error `don't` -> `doesn't`

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ enabled = true
 
 [servers]
 
-  # You can indent as you please. Tabs or spaces. TOML don't care.
+  # You can indent as you please. Tabs or spaces. TOML doesn't care.
   [servers.alpha]
   ip = "10.0.0.1"
   dc = "eqdc10"


### PR DESCRIPTION
I have fixed a grammar error introduced from PR #68.
