### PR TITLE
Adds multi-line string to spec.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ triple double quotes. Tabs, newlines, double quotes, and carriage returns
 do not need to be escaped inside a multi-line string primitive.
 
 ```toml
-"""
+notes = """
 I'm a multi-line string. You can
 
   * insert multiple lines and indent me if you like.


### PR DESCRIPTION
I think there should be some kind of baked-in support for multi-line strings, especially since that's the primary reason (IMO) that JSON sucks as a specification language. Here I'm adding the CoffeeScript style triple-quotes but I'm fine with anything, really.
