### PR TITLE
Reserve all other special characters so invalid Windows paths are easier to catch

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ Here is the list of special characters.
 \\ - backslash       (0x5c)
 ```
 
+Other special characters are reserved and, if used, TOML should produce an
+error. This means paths on Windows will always have to use double backslashes.
+
+```toml
+wrong = "C:\Users\nodejs\templates" # note: doesn't produce a valid path
+right = "C:\\Users\\nodejs\\templates"
+```
+
 Integers are bare numbers, all alone. Feeling negative? Do what's natural.
 64-bit minimum size expected.
 


### PR DESCRIPTION
For better or worse, a versatile config format has to consider Windows users as well. One of the most common value types in configuration are paths.

Reserving invalid special characters will help catching singly backslashed paths. I recognize it will still be possible to construct an invalid path that maps to known special characters only. Too bad.
