### PR TITLE
Be explicit that strings cannot span across multiple lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Primitives
 
 String, Integer, Float, Boolean, Datetime, Array.
 
-Strings are UTF8 surrounded by double quotes. Quotes and other special
-characters must be escaped.
+Strings are single-line values surrounded by double quotes encoded in UTF-8.
+Quotes and other special characters must be escaped.
 
 ```toml
 "I'm a string. \"You can quote me\". Tab \t newline \n you get it."


### PR DESCRIPTION
I mean, they have to be single line anyway.

Rationale:
- There is a correct way to encode line separators with special characters.
- Multi-line strings would be confusing in arrays anyway.
- Windows again (see #113): forcing strings to be single line helps when a user wrongly specifies a stranded backslash at the end of the string. That way it won't break parsing the rest of the configuration file.
