### PR TITLE
Added toml-js node/browser/amd version

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ note the commit SHA1 or version tag that your parser supports in your Readme.
 - node.js/browser - https://github.com/ricardobeat/toml
 - node.js - https://github.com/BinaryMuse/toml-node
 - node.js (@redhotvengeance) - https://github.com/redhotvengeance/topl (topl npm package)
+- node.js/browser (@alexanderbeletsky) - https://github.com/alexanderbeletsky/toml-js (npm browser amd)
 - Objective C (@mneorr) - https://github.com/mneorr/toml-objc.git
 - Objective-C (@SteveStreza) - https://github.com/amazingsyco/TOML
 - Perl (@alexkalderimis) - https://github.com/alexkalderimis/config-toml.pl


### PR DESCRIPTION
Supported version SHA1: a7e7e9e335c34131af3c86569b7d674b8d9412e1 (no multiline arrays).
