### PR TITLE
Format for anonymous hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,17 @@ hosts = [
   "alpha",
   "omega"
 ]
+
+# Anonymous hashes within arrays
+[dependencies.#]
+  [-]
+  groupId    = "com.google.api-client"
+  artifactId = "google-api-client"
+  version    = "1.13.2-beta"
+  [-]
+  groupId    = "com.google.api-client"
+  artifactId = "google-api-client-servlet"
+  version    = "1.13.1-beta"
 ```
 
 Spec

--- a/tests/example.toml
+++ b/tests/example.toml
@@ -33,3 +33,14 @@ hosts = [
   "alpha",
   "omega"
 ]
+
+# Anonymous hashes within arrays
+[dependencies.#]
+  [-]
+  groupId    = "com.google.api-client"
+  artifactId = "google-api-client"
+  version    = "1.13.2-beta"
+  [-]
+  groupId    = "com.google.api-client"
+  artifactId = "google-api-client-servlet"
+  version    = "1.13.1-beta"

--- a/tests/example.yaml
+++ b/tests/example.yaml
@@ -23,3 +23,11 @@ servers:
 clients:
   data: [ ["gamma", "delta"], [1, 2] ]
   hosts: [ "alpha", "omega" ]
+
+dependencies:
+- groupId: com.google.api-client
+  artifactId: google-api-client
+  version: 1.13.2-beta
+- groupId: com.google.api-client
+  artifactId: google-api-client-servlet
+  version: 1.13.1-beta


### PR DESCRIPTION
Proposed solution to lack of anonymous hashes in toml mojombo/toml#50

```
[dependencies.#]
  [-]
  groupId    = "com.google.api-client"
  artifactId = "google-api-client"
  version    = "1.13.2-beta"
  [-]
  groupId    = "com.google.api-client"
  artifactId = "google-api-client-servlet"
  version    = "1.13.1-beta"
```

Makes for easy reading and parsing.

`[dependencies.#]` tells the parser to make the value for the key `dependencies` an empty array and just push any of the subsequent hashes to the array.

`[-]` Tells the parser to start building a hash that will be pushed into the previously defined array as soon as the next key is found
