### PR TITLE
Add statically typed C++ implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ note the commit SHA1 or version tag that your parser supports in your Readme.
 
 - C#/.NET - https://github.com/LBreedlove/Toml.net
 - C#/.NET - https://github.com/rossipedia/toml-net
+- C++ (@evilncrazy) - https://github.com/evilncrazy/ctoml
 - Clojure (@lantiga) - https://github.com/lantiga/clj-toml
 - Clojure (@manicolosi) - https://github.com/manicolosi/clojoml
 - CoffeeScript (@biilmann) - https://github.com/biilmann/coffee-toml


### PR DESCRIPTION
Currently supports up to commit 6303a80 of the spec.
