### PR TITLE
Update repository and gem name from `toml_parser-ruby` to `toml-rb`

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ note the commit SHA1 or version tag that your parser supports in your Readme.
 - Python - https://github.com/bryant/pytoml
 - Python (@elssar) - https://github.com/elssar/tomlgun
 - Ruby (@jm) - https://github.com/jm/toml (toml gem)
-- Ruby (@eMancu) - https://github.com/eMancu/toml_parser-ruby (toml_parser-ruby gem)
+- Ruby (@eMancu) - https://github.com/eMancu/toml-rb (toml-rb gem)
 - Ruby (@charliesome) - https://github.com/charliesome/toml2 (toml2 gem)
 - Scala - https://github.com/axelarge/tomelette
 


### PR DESCRIPTION
I deprecated the old gem and create the new one with a better name.
