### PR TITLE
Preserve whitespace in expected hard array parsing values

### DIFF
--- a/tests/hard_example.yaml
+++ b/tests/hard_example.yaml
@@ -5,6 +5,6 @@ the:
       multi_line_array: [']']
       what?: You don't think some user won't do that?
     harder_test_string: ' And when "''s are in the string, along with # "'
-    test_array: [']', '#']
+    test_array: ['] ', ' # ']
     test_array2: ['Test #11 ]proved that', 'Experiment #9 was a success']
   test_string: 'You''ll hate me after this - #'


### PR DESCRIPTION
Given the input from hard_example.toml:

``` toml
    test_array = [ "] ", " # "]      # ] There you go, parse this!
```

I think the expected output should be

``` yaml
test_array: ['] ', ' # ']
```

And not

``` yaml
test_array: [']', '#']
```

That is, preserve whitespace in strings.
