### PR TITLE
Allow timezone offsets in Datetime

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,12 @@ false
 Datetime
 --------
 
-Datetimes are ISO 8601 dates, but only the full zulu form is allowed.
+Datetimes are [RFC 3339](http://tools.ietf.org/html/rfc3339) dates.
 
 ```toml
 1979-05-27T07:32:00Z
+1979-05-27T00:32:00-0700
+1979-05-27T00:32:00.999999-0700
 ```
 
 Array


### PR DESCRIPTION
The pull request introduces two changes to the Datetime documentation:
1. It references [RFC 3339](http://tools.ietf.org/html/rfc3339) instead of ISO 8601. The RFC is easily available on the internet, includes all the documentation needed to support the single datetime format supported by TOML, only includes documentation on timestamps (and not concepts like durations) and actually includes a formal grammar. In short, it's a much better document to reference in this spec.
2. It removes the restriction that all Datetimes should be in GMT.

There are many use cases for TOML where the timezone is significant information, particularly anywhere where TOML is being used to mark up activity by real people. For example, git's internal datetime format includes the timezone, and timezone offsets are mandatory in email messages. Converting either to TOML will cause a loss of data.

Perhaps the best example is the date already in the documentation. It looks a lot like a birthday - but for someone born in Hawaii there's an important difference between `1979-05-27T07:32:00Z` and `1979-05-26T21:32:00-10:00`. The zulu form doesn't actually give enough information to determine what day someone's birthday is.

This change is backward compatible, and should be easy to implement as most TOML parsers will be using a language's built in date parsing code. If not, subtracting a numeric offset is not a significant amount of work. 

In issue #94 the need to keep datetimes simple was mentioned. I think adding numeric timezone offsets doesn't introduce significant complexity, and is much simpler than applications that need timezone support manually adding it with strings.
