### PR TITLE
Add multi-byte UTF-8 string to example file

### DIFF
--- a/tests/example.toml
+++ b/tests/example.toml
@@ -24,6 +24,7 @@ enabled = true
   [servers.beta]
   ip = "10.0.0.2"
   dc = "eqdc10"
+  country = "中国" # This should be parsed as UTF-8
 
 [clients]
 data = [ ["gamma", "delta"], [1, 2] ] # just an update to make sure parsers support it

--- a/tests/example.yaml
+++ b/tests/example.yaml
@@ -19,6 +19,7 @@ servers:
   beta:
     ip: 10.0.0.2
     dc: eqdc10
+    country: "中国"
 
 clients:
   data: [ ["gamma", "delta"], [1, 2] ]


### PR DESCRIPTION
I've added one multi-byte UTF-8 string (Chinese) in the example file, so that parsers can check that they handle UTF-8 strings correctly.
