### PR TITLE
removed socketubs/pytoml Python lib (repo not there)

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,6 @@ note the commit SHA1 or version tag that your parser supports in your Readme.
 - PHP (@checkdomain) - https://github.com/checkdomain/toml
 - PHP (@zidizei) - https://github.com/zidizei/toml-php
 - PHP (@yosymfony) - https://github.com/yosymfony/toml
-- Python (@socketubs) - https://github.com/socketubs/pytoml
 - Python (@f03lipe) - https://github.com/f03lipe/toml-python
 - Python (@uiri) - https://github.com/uiri/toml
 - Python - https://github.com/bryant/pytoml


### PR DESCRIPTION
socketubs/pytoml is giving 404: https://github.com/socketubs/pytoml
