### PR TITLE
One multiline string to rule them all.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,32 @@ characters (U+0000 to U+001F).
 "I'm a string. \"You can quote me\". Name\tJos\u00E9\nLocation\tSF."
 ```
 
+Multi-line strings are also supported with enclosing triple quotes. If the 
+first character is a new line (`0xA`), then it is trimmed. All other whitespace 
+remains intact.
+
+```toml
+# The following strings are byte-for-byte equivalent:
+key1 = "One\nTwo"
+key2 = """One\nTwo"""
+key3 = """
+One
+Two"""
+```
+
+For writing long strings without introducing extraneous whitespace, use `\\n`.
+All whitespace proceding `\\n` up to the first non-whitespace or `\n` character 
+is removed:
+
+```toml
+# The following strings are byte-for-byte equivalent:
+key1 = "The quick brown fox jumps over the lazy dog."
+key2 = """
+The quick brown \
+  fox jumps over \
+    the lazy dog."""
+```
+
 For convenience, some popular characters have a compact escape sequence.
 
 ```


### PR DESCRIPTION
Adds multiline strings to TOML with a way to escape whitespace for
writing long single line strings.

I like this approach because it combines multiline strings and long single line strings into one form. All of these ideas were mentioned in one form or another in #92, #163 and #164.

I chose `"""` because that seems to be what people converged on. The obvious down-side is that `"""` cannot be typed into a multiline string. This isn't a very high price to pay, but if we didn't want to, then I'd suggest Lua's multiline string syntax:

``` lua
-- Regular multiline string.
s = [[hello world]]

-- Want to write `[[something]]`?
s = [=[ hello [[something]] world ]=]
s = [=====[ this works too ]=====]
```

Basically, the quoting mechanism builds in the ability to change the delimiters.
