### PR TITLE
Add ABNF description of TOML.

### DIFF
--- a/toml.abnf
+++ b/toml.abnf
@@ -1,34 +1,38 @@
+;; WARNING: This document is a work-in-progress and should not be considered
+;; authoritative until further notice.
+
 ;; This is an attempt to define TOML in ABNF according to the grammar defined
 ;; in RFC 5234 (http://www.ietf.org/rfc/rfc5234.txt).
 
-;; WARNING: This document is a work-in-progress and should not be considered
-;; authoritative until further notice.
+;; You can try out this grammar interactively via the online ABNF tool at
+;; http://www.coasttocoastresearch.com/interactiveapg
+;; Note that due to the limitations of ABNF parsers, in order for multi-line
+;; strings to work in that tool, the following rules must be ammended to
+;; disallow the use of unescaped double- or single-quotes:
+;; ml-basic-unescaped = basic-unescaped
+;; ml-literal-char = literal-char
 
 ;; TOML
 
 toml = expression *( newline expression )
-expression = (
-  ws /
-  ( ws comment ) /
-  ( ws keyval ws [ comment ] ) /
-  ( ws table ws [ comment ] )
-)
+expression = ( ( ws comment ) /
+               ( ws keyval ws [ comment ] ) /
+               ( ws table ws [ comment ] ) /
+                 ws )
 
 ;; Newline
 
-newline = (
-  %x0A /              ; LF
-  %x0D.0A             ; CRLF
-)
+newline = ( %x0A /              ; LF
+            %x0D.0A )           ; CRLF
 
 newlines = 1*newline
 
 ;; Whitespace
 
-ws = *(
-  %x20 /              ; Space
-  %x09                ; Horizontal tab
-)
+wschar = ( %x20 /              ; Space
+           %x09 )              ; Horizontal tab
+
+ws = *wschar
 
 ;; Comment
 
@@ -45,7 +49,7 @@ key = unquoted-key / quoted-key
 unquoted-key = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
 quoted-key = quotation-mark 1*basic-char quotation-mark ; See Basic Strings
 
-val = integer / float / string / boolean / date-time / array / inline-table
+val = string / boolean / array / inline-table / date-time / float / integer
 
 ;; Table
 
@@ -77,7 +81,7 @@ int = DIGIT / digit1-9 1*( DIGIT / underscore DIGIT )
 
 ;; Float
 
-float = integer ( frac / frac exp / exp )
+float = integer ( frac / ( frac exp ) / exp )
 zero-prefixable-int = DIGIT *( DIGIT / underscore DIGIT )
 frac = decimal-point zero-prefixable-int
 decimal-point = %x2E               ; .
@@ -86,7 +90,7 @@ e = %x65 / %x45                    ; e E
 
 ;; String
 
-string = basic-string / ml-basic-string / literal-string / ml-literal-string
+string = ml-basic-string / basic-string / ml-literal-string / literal-string
 
 ;; Basic String
 
@@ -112,7 +116,7 @@ escape = %x5C                    ; \
 
 ;; Multiline Basic String
 
-ml-basic-string-delim = quotation-mark quotation-mark quotation-mark
+ml-basic-string-delim = 3quotation-mark
 ml-basic-string = ml-basic-string-delim ml-basic-body ml-basic-string-delim
 ml-basic-body = *( ml-basic-char / newline / ( escape newline ))
 
@@ -121,15 +125,15 @@ ml-basic-unescaped = %x20-5B / %x5D-10FFFF
 
 ;; Literal String
 
-literal-string = apostraphe *literal-char apostraphe
+literal-string = apostrophe *literal-char apostrophe
 
-apostraphe = %x27 ; ' Apostraphe
+apostrophe = %x27 ; ' apostrophe
 
 literal-char = %x09 / %x20-26 / %x28-10FFFF
 
 ;; Multiline Literal String
 
-ml-literal-string-delim = apostraphe apostraphe apostraphe
+ml-literal-string-delim = 3apostrophe
 ml-literal-string = ml-literal-string-delim ml-literal-body ml-literal-string-delim
 
 ml-literal-body = *( ml-literal-char / newline )
@@ -177,16 +181,16 @@ local-time = partial-time
 
 ;; Array
 
-ws-newline       = *( ws / newline )
-ws-newlines      = newline *( ws / newline )
+ws-newline       = *( wschar / newline )
+ws-newlines      = newline *( wschar / newline )
 
 array-open  = %x5B ws-newline  ; [
 array-close = ws-newline %x5D  ; ]
 
 array = array-open array-values array-close
 
-array-values = [ ( val [ array-sep ] [ ( ws-newline comment ws-newlines ) ] ) /
-                 ( val array-sep [ ( ws-newline comment ws-newlines) / ws-newlines ] array-values ) ]
+array-values = [ ( val array-sep [ ( ws-newline comment ws-newlines) / ws-newlines ] array-values ) /
+                 ( val [ array-sep ] [ ( ws-newline comment ws-newlines ) ] ) ]
 
 array-sep = ws %x2C ws  ; , Comma
 
@@ -199,11 +203,11 @@ inline-table-sep   = ws %x2C ws  ; , Comma
 inline-table = inline-table-open inline-table-keyvals inline-table-close
 
 inline-table-keyvals = [ inline-table-keyvals-non-empty ]
-inline-table-keyvals-non-empty = ( key keyval-sep val ) /
-                                 ( key keyval-sep val inline-table-sep inline-table-keyvals-non-empty )
+inline-table-keyvals-non-empty = ( key keyval-sep val inline-table-sep inline-table-keyvals-non-empty ) /
+                                 ( key keyval-sep val )
 
 ;; Built-in ABNF terms, reproduced here for clarity
 
-; ALPHA = %x41-5A / %x61-7A ; A-Z / a-z
-; DIGIT = %x30-39 ; 0-9
-; HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
+ALPHA = %x41-5A / %x61-7A ; A-Z / a-z
+DIGIT = %x30-39 ; 0-9
+HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"

--- a/toml.abnf
+++ b/toml.abnf
@@ -57,7 +57,7 @@ std-table = std-table-open key *( table-key-sep key) std-table-close
 ;; Array Table
 
 array-table-open  = %x5B.5B ws  ; [[ Double left square bracket
-array-table-close = %x5D.5D ws  ; ]] Double right quare bracket
+array-table-close = ws %x5D.5D  ; ]] Double right quare bracket
 
 array-table = array-table-open key *( table-key-sep key) array-table-close
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -68,14 +68,15 @@ array-table = array-table-open key *( table-key-sep key) array-table-close
 integer = [ minus / plus ] int
 minus = %x2D                       ; -
 plus = %x2B                        ; +
-int = zero / ( digit1-9 *DIGIT )
-zero = %x30                        ; 0
 digit1-9 = %x31-39                 ; 1-9
+underscore = %x5F                  ; _
+int = DIGIT / digit1-9 1*( DIGIT / underscore DIGIT )
 
 ;; Float
 
 float = integer ( frac / frac exp / exp )
-frac = decimal-point 1*DIGIT
+zero-prefixable-int = DIGIT *( DIGIT / underscore DIGIT )
+frac = decimal-point zero-prefixable-int
 decimal-point = %x2E               ; .
 exp = e integer
 e = %x65 / %x45                    ; e E

--- a/toml.abnf
+++ b/toml.abnf
@@ -37,7 +37,7 @@ keyval-sep = ws %x3D ws ; =
 keyval = key keyval-sep val
 
 key = unquoted-key / quoted-key
-unquoted-key = 1*ALPHA
+unquoted-key = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
 quoted-key = quotation-mark 1*basic-char quotation-mark ; See Basic Strings
 
 val = integer / float / string / boolean / datetime / array / inline-table

--- a/toml.abnf
+++ b/toml.abnf
@@ -1,6 +1,9 @@
 ;; This is an attempt to define TOML in ABNF according to the grammar defined
 ;; in RFC 4234 (http://www.ietf.org/rfc/rfc4234.txt).
 
+;; WARNING: This document is a work-in-progress and should not be considered
+;; authoritative until further notice.
+
 ;; TOML
 
 toml = expression *( newline expression )

--- a/toml.abnf
+++ b/toml.abnf
@@ -26,8 +26,6 @@ expression = ( ( ws comment ) /
 newline = ( %x0A /              ; LF
             %x0D.0A )           ; CRLF
 
-newlines = 1*newline
-
 ;; Whitespace
 
 ws = *wschar

--- a/toml.abnf
+++ b/toml.abnf
@@ -169,8 +169,8 @@ array-close = ws-newline %x5D  ; ]
 
 array = array-open array-values array-close
 
-array-values = ( [ val [ array-sep ] [ ( ws-newline comment ws-newlines ) ] ) /
-                 ( val array-sep [ ( ws-newline comment ws-newlines) / ws-newlines ] array-values ] )
+array-values = [ ( val [ array-sep ] [ ( ws-newline comment ws-newlines ) ] ) /
+                 ( val array-sep [ ( ws-newline comment ws-newlines) / ws-newlines ] array-values ) ]
 
 array-sep = ws %x2C ws  ; , Comma
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -63,20 +63,20 @@ array-table = array-table-open key *( table-key-sep key) array-table-close
 
 ;; Integer
 
-integer = [ minus ] int
+integer = [ minus / plus ] int
 minus = %x2D                       ; -
+plus = %x2B                        ; +
 int = zero / ( digit1-9 *DIGIT )
 zero = %x30                        ; 0
 digit1-9 = %x31-39                 ; 1-9
 
 ;; Float
 
-float = [ minus ] int [ frac ] [ exp ]
+float = integer ( frac / frac exp / exp )
 frac = decimal-point 1*DIGIT
 decimal-point = %x2E               ; .
-exp = e [ minus / plus ] 1*DIGIT
+exp = e integer
 e = %x65 / %x45                    ; e E
-plus = %x2B                        ; +
 
 ;; String
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -15,6 +15,7 @@
 ;; TOML
 
 toml = expression *( newline expression )
+
 expression = ( ( ws comment ) /
                ( ws keyval ws [ comment ] ) /
                ( ws table ws [ comment ] ) /
@@ -29,10 +30,10 @@ newlines = 1*newline
 
 ;; Whitespace
 
+ws = *wschar
+
 wschar = ( %x20 /              ; Space
            %x09 )              ; Horizontal tab
-
-ws = *wschar
 
 ;; Comment
 
@@ -42,12 +43,13 @@ comment = comment-start-symbol *non-eol
 
 ;; Key-Value pairs
 
-keyval-sep = ws %x3D ws ; =
 keyval = key keyval-sep val
 
 key = unquoted-key / quoted-key
 unquoted-key = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
 quoted-key = quotation-mark 1*basic-char quotation-mark ; See Basic Strings
+
+keyval-sep = ws %x3D ws ; =
 
 val = string / boolean / array / inline-table / date-time / float / integer
 
@@ -57,34 +59,38 @@ table = std-table / array-table
 
 ;; Standard Table
 
+std-table = std-table-open key *( table-key-sep key) std-table-close
+
 std-table-open  = %x5B ws     ; [ Left square bracket
 std-table-close = ws %x5D     ; ] Right square bracket
 table-key-sep   = ws %x2E ws  ; . Period
 
-std-table = std-table-open key *( table-key-sep key) std-table-close
-
 ;; Array Table
+
+array-table = array-table-open key *( table-key-sep key) array-table-close
 
 array-table-open  = %x5B.5B ws  ; [[ Double left square bracket
 array-table-close = ws %x5D.5D  ; ]] Double right quare bracket
 
-array-table = array-table-open key *( table-key-sep key) array-table-close
-
 ;; Integer
 
 integer = [ minus / plus ] int
+
 minus = %x2D                       ; -
 plus = %x2B                        ; +
+
+int = DIGIT / digit1-9 1*( DIGIT / underscore DIGIT )
 digit1-9 = %x31-39                 ; 1-9
 underscore = %x5F                  ; _
-int = DIGIT / digit1-9 1*( DIGIT / underscore DIGIT )
 
 ;; Float
 
 float = integer ( frac / ( frac exp ) / exp )
-zero-prefixable-int = DIGIT *( DIGIT / underscore DIGIT )
+
 frac = decimal-point zero-prefixable-int
 decimal-point = %x2E               ; .
+zero-prefixable-int = DIGIT *( DIGIT / underscore DIGIT )
+
 exp = e integer
 e = %x65 / %x45                    ; e E
 
@@ -99,6 +105,7 @@ basic-string = quotation-mark *basic-char quotation-mark
 quotation-mark = %x22            ; "
 
 basic-char = basic-unescaped / escaped
+basic-unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
 escaped = escape ( %x22 /          ; "    quotation mark  U+0022
                    %x5C /          ; \    reverse solidus U+005C
                    %x2F /          ; /    solidus         U+002F
@@ -110,16 +117,15 @@ escaped = escape ( %x22 /          ; "    quotation mark  U+0022
                    %x75 4HEXDIG /  ; uXXXX                U+XXXX
                    %x55 8HEXDIG )  ; UXXXXXXXX            U+XXXXXXXX
 
-basic-unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
-
 escape = %x5C                    ; \
 
 ;; Multiline Basic String
 
-ml-basic-string-delim = 3quotation-mark
 ml-basic-string = ml-basic-string-delim ml-basic-body ml-basic-string-delim
-ml-basic-body = *( ml-basic-char / newline / ( escape newline ))
 
+ml-basic-string-delim = 3quotation-mark
+
+ml-basic-body = *( ml-basic-char / newline / ( escape newline ))
 ml-basic-char = ml-basic-unescaped / escaped
 ml-basic-unescaped = %x20-5B / %x5D-10FFFF
 
@@ -133,8 +139,9 @@ literal-char = %x09 / %x20-26 / %x28-10FFFF
 
 ;; Multiline Literal String
 
-ml-literal-string-delim = 3apostrophe
 ml-literal-string = ml-literal-string-delim ml-literal-body ml-literal-string-delim
+
+ml-literal-string-delim = 3apostrophe
 
 ml-literal-body = *( ml-literal-char / newline )
 ml-literal-char = %x09 / %x20-10FFFF
@@ -142,10 +149,13 @@ ml-literal-char = %x09 / %x20-10FFFF
 ;; Boolean
 
 boolean = true / false
+
 true    = %x74.72.75.65     ; true
 false   = %x66.61.6C.73.65  ; false
 
 ;; Date and Time (as defined in RFC 3339)
+
+date-time      = offset-date-time / local-date-time / local-date / local-time
 
 date-fullyear  = 4DIGIT
 date-month     = 2DIGIT  ; 01-12
@@ -160,8 +170,6 @@ time-offset    = "Z" / time-numoffset
 partial-time   = time-hour ":" time-minute ":" time-second [time-secfrac]
 full-date      = date-fullyear "-" date-month "-" date-mday
 full-time      = partial-time time-offset
-
-date-time      = offset-date-time / local-date-time / local-date / local-time
 
 ;; Offset Date-Time
 
@@ -181,26 +189,26 @@ local-time = partial-time
 
 ;; Array
 
-ws-newline       = *( wschar / newline )
-ws-newlines      = newline *( wschar / newline )
+array = array-open array-values array-close
 
 array-open  = %x5B ws-newline  ; [
 array-close = ws-newline %x5D  ; ]
-
-array = array-open array-values array-close
 
 array-values = [ ( val array-sep [ ( ws-newline comment ws-newlines) / ws-newlines ] array-values ) /
                  ( val [ array-sep ] [ ( ws-newline comment ws-newlines ) ] ) ]
 
 array-sep = ws %x2C ws  ; , Comma
 
+ws-newline       = *( wschar / newline )
+ws-newlines      = newline *( wschar / newline )
+
 ;; Inline Table
+
+inline-table = inline-table-open inline-table-keyvals inline-table-close
 
 inline-table-open  = %x7B ws     ; {
 inline-table-close = ws %x7D     ; }
 inline-table-sep   = ws %x2C ws  ; , Comma
-
-inline-table = inline-table-open inline-table-keyvals inline-table-close
 
 inline-table-keyvals = [ inline-table-keyvals-non-empty ]
 inline-table-keyvals-non-empty = ( key keyval-sep val inline-table-sep inline-table-keyvals-non-empty ) /

--- a/toml.abnf
+++ b/toml.abnf
@@ -99,7 +99,8 @@ escaped = escape ( %x22 /          ; "    quotation mark  U+0022
                    %x6E /          ; n    line feed       U+000A
                    %x72 /          ; r    carriage return U+000D
                    %x74 /          ; t    tab             U+0009
-                   %x75 4HEXDIG )  ; uXXXX                U+XXXX
+                   %x75 4HEXDIG /  ; uXXXX                U+XXXX
+                   %x55 8HEXDIG )  ; UXXXXXXXX            U+XXXXXXXX
 
 basic-unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -141,7 +141,7 @@ boolean = true / false
 true    = %x74.72.75.65     ; true
 false   = %x66.61.6C.73.65  ; false
 
-;; Datetime (as defined in RFC 3339)
+;; Date and Time (as defined in RFC 3339)
 
 date-fullyear  = 4DIGIT
 date-month     = 2DIGIT  ; 01-12
@@ -157,7 +157,23 @@ partial-time   = time-hour ":" time-minute ":" time-second [time-secfrac]
 full-date      = date-fullyear "-" date-month "-" date-mday
 full-time      = partial-time time-offset
 
-date-time      = full-date "T" full-time
+date-time      = offset-date-time / local-date-time / local-date / local-time
+
+;; Offset Date-Time
+
+offset-date-time = full-date "T" full-time
+
+;; Local Date-Time
+
+local-date-time = full-date "T" partial-time
+
+;; Local Date
+
+local-date = full-date
+
+;; Local Time
+
+local-time = partial-time
 
 ;; Array
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -18,7 +18,7 @@ newline = (
   %x0D.0A             ; CRLF
 )
 
-newlines = 1*( newline )
+newlines = 1*newline
 
 ;; Whitespace
 
@@ -136,7 +136,7 @@ ml-literal-char = %x09 / %x20-10FFFF
 
 boolean = true / false
 true    = %x74.72.75.65     ; true
-false   = %x66.61.6c.73.65  ; false
+false   = %x66.61.6C.73.65  ; false
 
 ;; Datetime (as defined in RFC 3339)
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -1,0 +1,175 @@
+;; This is an attempt to define TOML in ABNF according to the grammar defined
+;; in RFC 4234 (http://www.ietf.org/rfc/rfc4234.txt).
+
+;; TOML
+
+toml = expression *( newline expression )
+expression = (
+  ws /
+  ws comment /
+  ws keyval ws [ comment ] /
+  ws table ws [ comment ]
+)
+
+;; Newline
+
+newline = 1*(
+  %x0A /              ; Line feed or New line
+  %x0D                ; Carriage return
+)
+
+;; Whitespace
+
+ws = *(
+  %x20 /              ; Space
+  %x09                ; Horizontal tab
+)
+
+;; Comment
+
+comment-start-symbol = %x23 ; #
+non-eol = %x09 / %x20-10FFFF
+comment = comment-start-symbol *non-eol
+
+;; Key-Value pairs
+
+keyval-sep = ws %x3D ws ; =
+keyval = key keyval-sep val
+
+key = unquoted-key / quoted-key
+unquoted-key = 1*ALPHA
+quoted-key = quotation-mark 1*basic-char quotation-mark ; See Basic Strings
+
+val = integer / float / string / boolean / datetime / array / inline-table
+
+;; Table
+
+table = std-table / array-table
+
+;; Standard Table
+
+std-table-open  = %x5B ws     ; [ Left square bracket
+std-table-close = ws %x5D     ; ] Right square bracket
+table-key-sep   = ws %x2E ws  ; . Period
+
+std-table = std-table-open key *( table-key-sep key) std-table-close
+
+;; Array Table
+
+array-table-open  = %x5B.5B ws  ; [[ Double left square bracket
+array-table-close = %x5D.5D ws  ; ]] Double right quare bracket
+
+array-table = array-table-open key *( table-key-sep key) array-table-close
+
+;; Integer
+
+integer = [ minus ] int
+minus = %x2D                       ; -
+int = zero / ( digit1-9 *DIGIT )
+zero = %x30                        ; 0
+digit1-9 = %x31-39                 ; 1-9
+
+;; Float
+
+float = [ minus ] int [ frac ] [ exp ]
+frac = decimal-point 1*DIGIT
+decimal-point = %x2E               ; .
+exp = e [ minus / plus ] 1*DIGIT
+e = %x65 / %x45                    ; e E
+plus = %x2B                        ; +
+
+;; String
+
+string = basic-string / ml-basic-string / literal-string / ml-literal-string
+
+;; Basic String
+
+basic-string = quotation-mark *basic-char quotation-mark
+
+quotation-mark = %x22            ; "
+
+basic-char = basic-unescaped / escaped
+escaped = escape ( %x22 /          ; "    quotation mark  U+0022
+                   %x5C /          ; \    reverse solidus U+005C
+                   %x2F /          ; /    solidus         U+002F
+                   %x62 /          ; b    backspace       U+0008
+                   %x66 /          ; f    form feed       U+000C
+                   %x6E /          ; n    line feed       U+000A
+                   %x72 /          ; r    carriage return U+000D
+                   %x74 /          ; t    tab             U+0009
+                   %x75 4HEXDIG )  ; uXXXX                U+XXXX
+
+basic-unescaped = %x20-21 / %x23-5B / %x5D-10FFFF
+
+escape = %x5C                    ; \
+
+;; Multiline Basic String
+
+ml-basic-string-delim = quotation-mark quotation-mark quotation-mark
+ml-basic-string = ml-basic-string-delim ml-basic-body ml-basic-string-delim
+ml-basic-body = *( ml-basic-char / ( escape newline ))
+
+ml-basic-char = ml-basic-unescaped / escaped
+ml-basic-unescaped = %x20-5B / %x5D-10FFFF
+
+;; Literal String
+
+literal-string = apostraphe *literal-char apostraphe
+
+apostraphe = %x27 ; ' Apostraphe
+
+literal-char = %x09 / %x20-26 / %x28-10FFFF
+
+;; Multiline Literal String
+
+ml-literal-string-delim = apostraphe apostraphe apostraphe
+ml-literal-string = ml-literal-string-delim ml-literal-body ml-literal-string-delim
+
+ml-literal-body = *( ml-literal-char / newline )
+ml-literal-char = %x09 / %x20-10FFFF
+
+;; Boolean
+
+boolean = true / false
+true    = %x74.72.75.65     ; true
+false   = %x66.61.6c.73.65  ; false
+
+;; Datetime
+
+datetime = ymd tee hms zee
+ymd = 4DIGIT dash 2DIGIT dash 2DIGIT
+hms = 2DIGIT colon 2DIGIT colon 2DIGIT
+dash = %x2D  ; -
+colon = %x3A ; :
+tee = %x54   ; T
+zee = %x5A   ; Z
+
+;; Array
+
+array-open  = %x5B ws  ; [
+array-close = ws %x5D  ; ]
+
+array = array-open array-values array-close
+
+array-values = [ val [ array-sep ] [ ( comment newline) / newline ] /
+                 val array-sep [ ( comment newline) / newline ] array-values ]
+
+array-sep = ws %x2C ws  ; , Comma
+
+;; Inline Table
+
+inline-table-open  = %x7B ws     ; {
+inline-table-close = ws %x7D     ; }
+inline-table-sep   = ws %x2C ws  ; , Comma
+
+inline-table = inline-table-open inline-table-keyvals inline-table-close
+
+inline-table-keyvals = [ inline-table-keyvals-non-empty ]
+inline-table-keyvals-non-empty = key keyval-sep val /
+                                 key keyval-sep val inline-table-sep inline-table-keyvals-non-empty
+
+;; Built-in ABNF terms, reproduced here for clarity
+
+; ALPHA = %x41-5A / %x61-7A ; A-Z / a-z
+; DIGIT = %x30-39 ; 0-9
+; HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"

--- a/toml.abnf
+++ b/toml.abnf
@@ -40,7 +40,7 @@ key = unquoted-key / quoted-key
 unquoted-key = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
 quoted-key = quotation-mark 1*basic-char quotation-mark ; See Basic Strings
 
-val = integer / float / string / boolean / datetime / array / inline-table
+val = integer / float / string / boolean / date-time / array / inline-table
 
 ;; Table
 
@@ -134,15 +134,23 @@ boolean = true / false
 true    = %x74.72.75.65     ; true
 false   = %x66.61.6c.73.65  ; false
 
-;; Datetime
+;; Datetime (as defined in RFC 3339)
 
-datetime = ymd tee hms zee
-ymd = 4DIGIT dash 2DIGIT dash 2DIGIT
-hms = 2DIGIT colon 2DIGIT colon 2DIGIT
-dash = %x2D  ; -
-colon = %x3A ; :
-tee = %x54   ; T
-zee = %x5A   ; Z
+date-fullyear  = 4DIGIT
+date-month     = 2DIGIT  ; 01-12
+date-mday      = 2DIGIT  ; 01-28, 01-29, 01-30, 01-31 based on month/year
+time-hour      = 2DIGIT  ; 00-23
+time-minute    = 2DIGIT  ; 00-59
+time-second    = 2DIGIT  ; 00-58, 00-59, 00-60 based on leap second rules
+time-secfrac   = "." 1*DIGIT
+time-numoffset = ( "+" / "-" ) time-hour ":" time-minute
+time-offset    = "Z" / time-numoffset
+
+partial-time   = time-hour ":" time-minute ":" time-second [time-secfrac]
+full-date      = date-fullyear "-" date-month "-" date-mday
+full-time      = partial-time time-offset
+
+date-time      = full-date "T" full-time
 
 ;; Array
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -1,5 +1,5 @@
 ;; This is an attempt to define TOML in ABNF according to the grammar defined
-;; in RFC 4234 (http://www.ietf.org/rfc/rfc4234.txt).
+;; in RFC 5234 (http://www.ietf.org/rfc/rfc5234.txt).
 
 ;; WARNING: This document is a work-in-progress and should not be considered
 ;; authoritative until further notice.

--- a/toml.abnf
+++ b/toml.abnf
@@ -13,10 +13,12 @@ expression = (
 
 ;; Newline
 
-newline = 1*(
-  %x0A /              ; Line feed or New line
-  %x0D                ; Carriage return
+newline = (
+  %x0A /              ; LF
+  %x0D.0A             ; CRLF
 )
+
+newlines = 1*( newline )
 
 ;; Whitespace
 
@@ -107,7 +109,7 @@ escape = %x5C                    ; \
 
 ml-basic-string-delim = quotation-mark quotation-mark quotation-mark
 ml-basic-string = ml-basic-string-delim ml-basic-body ml-basic-string-delim
-ml-basic-body = *( ml-basic-char / ( escape newline ))
+ml-basic-body = *( ml-basic-char / newline / ( escape newline ))
 
 ml-basic-char = ml-basic-unescaped / escaped
 ml-basic-unescaped = %x20-5B / %x5D-10FFFF
@@ -159,8 +161,8 @@ array-close = ws %x5D  ; ]
 
 array = array-open array-values array-close
 
-array-values = [ val [ array-sep ] [ ( comment newline) / newline ] /
-                 val array-sep [ ( comment newline) / newline ] array-values ]
+array-values = [ val [ array-sep ] [ ( comment newlines) / newlines ] /
+                 val array-sep [ ( comment newlines) / newlines ] array-values ]
 
 array-sep = ws %x2C ws  ; , Comma
 


### PR DESCRIPTION
One of the most important things we'll need for the TOML 1.0 release is a proper grammar. I've worked one up here as a starting point. I chose RFC 4234 ABNF because it feels much more modern and suitable for a Unicode world than ISO EBNF. Also, JSON uses ABNF and so many people should already be familiar with it.

This grammar should be complete. It also includes scientific notation for floats, as I expect those will go in soon.

I'm certainly no ABNF expert, and I'd love any suggestions for making this grammar more readable.
