### PR TITLE
Clarify whitespace and newline rules.

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Since there is no escaping, there is no way to write a single quote inside a
 literal string enclosed by single quotes. Luckily, TOML supports a multi-line
 version of literal strings that solves this problem. **Multi-line literal
 strings** are surrounded by three single quotes on each side and allow newlines.
-Like literal strings, there is no escaping whatsoever. Any newlines immediately
+Like literal strings, there is no escaping whatsoever. A newline immediately
 following the opening delimiter will be trimmed. All other content between the
 delimiters is interpreted as-is without modification.
 


### PR DESCRIPTION
This PR greatly clarifies the use of whitespace and newlines in TOML. A few notes and ramifications:
- Behavior on Windows is noted.
- Key and table names cannot contain any whitespace, even around brackets or dots.
- Keys and dot-separated table parts follow the exact same rules.
