### PR TITLE
Specify nanosecond precision for datetimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ false
 Datetime
 --------
 
-Datetimes are [RFC 3339](http://tools.ietf.org/html/rfc3339) dates.
+Datetimes are [RFC 3339](http://tools.ietf.org/html/rfc3339) dates with nanosecond precision.
 
 ```toml
 1979-05-27T07:32:00Z


### PR DESCRIPTION
As far as I can tell, RFC 3339 doesn't specify a maximum precision for the fractional seconds portion of the time. This is tough when parsing, as if I have to support arbitrarily precise times, I can't store the fractional seconds in a fixed size field: it's possible for it to be larger than an int, or a long, or whatever else.

This change makes nanoseconds the maximum precision. With that I can store the fractional portion in a 32 bit int.

Nanoseconds seemed precise enough to me as that's the highest precision I've seen returned by system clocks and the highest precision I've seen returned by databases. Milliseconds could also be interesting since that'd allow the whole datetime to be stored in a long, but I don't think it's worth restricting some use that wants to store the extra precision.