### PR TITLE
Unicode escapes must be scalar values

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ For convenience, some popular characters have a compact escape sequence.
 ```
 
 Any Unicode character may be escaped with the `\uXXXX` or `\UXXXXXXXX` forms.
-Note that the escape codes must be valid Unicode code points.
+The escape codes must be valid Unicode [scalar values](http://unicode.org/glossary/#unicode_scalar_value).
 
 Other special characters are reserved and, if used, TOML should produce an
 error.


### PR DESCRIPTION
Code points was not precise enough.

Explicitly disallow the JSON UTF-16 surrogate hack which would cause portability issues.

(Something Python 3 should have done, incidentally; as of Python 3.4 you can build UCS-2 strings that can't be printed to a UTF-8 stream)