### PR TITLE
Fix typo in README: "langage" -> "language"

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ Yuuuup. Wanna help? Send a pull request. Or write a parser. BE BRAVE.
 Projects using TOML
 -------------------
 
-- [Cargo](http://doc.crates.io/) - The Rust langage's package manager.
+- [Cargo](http://doc.crates.io/) - The Rust language's package manager.
 - [InfluxDB](http://influxdb.com/) - Distributed time series database.
 - [Haka](https://hekad.readthedocs.org) - Stream processing system by Mozilla.
 - [Hugo](http://gohugo.io/) - Static site generator in Go.


### PR DESCRIPTION
Fix a typo in `README` / Projects using TOML.