### PR TITLE
Add MeTA to TOML-using projects.

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,7 @@ Projects using TOML
 - [Heka](https://hekad.readthedocs.org) - Stream processing system by Mozilla.
 - [Hugo](http://gohugo.io/) - Static site generator in Go.
 - [bloom.api](https://github.com/untoldone/bloomapi) - Create APIs out of public datasources.
+- [MeTA](https://github.com/meta-toolkit/meta) - Modern C++ data science toolkit.
 
 Implementations
 ---------------


### PR DESCRIPTION
MeTA uses TOML for all of its configuration. More info on functionality is [on our website](https://meta-toolkit.github.io/meta/).

A few examples of how we use TOML: [specifying text tokenization pipelines](https://meta-toolkit.github.io/meta/analyzers-filters-tutorial.html), [specifying classifiers](https://meta-toolkit.github.io/meta/classify-tutorial.html), [a complete configuration file](https://github.com/meta-toolkit/meta/blob/develop/config.toml) that contains setup for datasets, etc.