### PR TITLE
Add another Ruby parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,7 @@ note the version tag that your parser supports in your Readme.
 - PHP (@leonelquinteros) - https://github.com/leonelquinteros/php-toml.git
 - Python (@avakar) - https://github.com/avakar/pytoml
 - Ruby (@emancu) - https://github.com/emancu/toml-rb (toml-rb gem)
+- Ruby (@fbernier) - https://github.com/fbernier/tomlrb (tomlrb gem)
 - Rust (@alexcrichton) - https://github.com/alexcrichton/toml-rs
 
 ### v0.3.1 compliant


### PR DESCRIPTION
Here is another Ruby parser supporting the 0.4.0 version of the spec. It's using [Racc](https://github.com/tenderlove/racc).

Thanks!