### PR TITLE
listed toml-scala in pre-v0.1.0 implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,7 @@ note the version tag that your parser supports in your Readme.
 - Ruby (@sandeepravi) - https://github.com/sandeepravi/tomlp (tomlp gem)
 - Rust (@mneumann) - https://github.com/mneumann/rust-toml
 - Scala - https://github.com/axelarge/tomelette
+- Scala - https://github.com/loop-less-code/toml-parser
 
 Validators
 ----------


### PR DESCRIPTION
i have written an implementation for toml in scala for pre-v0.1.0 version. 