### PR TITLE
Treat Dates and Datetimes as separate types

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,10 +299,20 @@ bool1 = true
 bool2 = false
 ```
 
+Date
+----
+
+Dates can be specified in `YYYY-MM-DD` format. A date does not model time;
+for this, use a datetime (below).
+
+```toml
+1979-05-27
+```
+
 Datetime
 --------
 
-There are three ways to express a datetime. The first is simply by using the
+There are two ways to express a datetime. The first is simply by using the
 [RFC 3339](http://tools.ietf.org/html/rfc3339) spec.
 
 ```toml
@@ -317,14 +327,6 @@ information. A good default is to use the host machine's local offset.
 ```toml
 1979-05-27T07:32:00
 1979-05-27T00:32:00.999999
-```
-
-If you only care about the day, you can omit the local offset and the time,
-letting the parser or host application decide both. Good defaults are to use the
-host machine's local offset and 00:00:00.
-
-```toml
-1979-05-27
 ```
 
 The precision of fractional seconds is implementation specific, but at least


### PR DESCRIPTION
I think the current direction of handling DateTimes with no time (PR #297) is going to lead to unnecessary confusion. While it's true that every day ought to have a "noon" (as suggested for PR #361), I don't think that it's going to be intuitive for users that the following TOML is parsed as being today at noon:

``` toml
backtothefuture = 2015-10-21
```

To me, this simply says that key `backtothefuture` represents the date "Wednesday October 21st, 2015".

I think, if we want to support time-less dates, let's do exactly that and be explicit about it. We already have specific types for these things in many programming languages (e.g., ruby and python both have `Date` as well as `DateTime`), and if we don't specify a time, in the config, let's just not model it. This gets rid of the problem of trying to have a "default" time for time-less DateTimes, and I think is intuitive and not complicated.
