### PR TITLE
Allow arrays of arrays of different types even more explicitly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,9 @@ Array
 -----
 
 Arrays are square brackets with other primitives inside. Whitespace is ignored.
-Elements are separated by commas. Data types may not be mixed (though all string
-types should be considered the same type).
+Elements are separated by commas. Data types may not be mixed (different ways to
+define strings should be considered the same type, and so should arrays with
+different element types).
 
 ```toml
 arr1 = [ 1, 2, 3 ]


### PR DESCRIPTION
There already was an example showing it's legal, so it isn't strictly necessary, but there was one for different kinds of strings as well. Also changes "string types should be considered a single type" to avoid overloading "type".