### PR TITLE
Added grouping to ambiguous alternatives, allow leading newlines inside arrays and spaces after newlines before array elements and newlines and spaces before comments in arrays

### DIFF
--- a/toml.abnf
+++ b/toml.abnf
@@ -161,7 +161,7 @@ date-time      = full-date "T" full-time
 ws-newline       = *(ws / newline)
 
 array-open  = %x5B ws-newline  ; [
-array-close = ws-newline %x5D  ; ]
+array-close = ws %x5D  ; ]
 
 array = array-open array-values array-close
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -162,11 +162,11 @@ ws-newline       = *( ws / newline )
 ws-newlines      = newline *( ws / newline )
 
 array-open  = %x5B ws-newline  ; [
-array-close = ws %x5D  ; ]
+array-close = ws-newline %x5D  ; ]
 
 array = array-open array-values array-close
 
-array-values = ( [ val [ array-sep ] [ ( ws-newline comment ws-newlines) / ws-newlines ] ) /
+array-values = ( [ val [ array-sep ] [ ( ws-newline comment ws-newlines ) ] ) /
                  ( val array-sep [ ( ws-newline comment ws-newlines) / ws-newlines ] array-values ] )
 
 array-sep = ws %x2C ws  ; , Comma

--- a/toml.abnf
+++ b/toml.abnf
@@ -158,8 +158,10 @@ date-time      = full-date "T" full-time
 
 ;; Array
 
-array-open  = %x5B ws  ; [
-array-close = ws %x5D  ; ]
+ws-newline       = *(ws / newline)
+
+array-open  = %x5B ws-newline  ; [
+array-close = ws-newline %x5D  ; ]
 
 array = array-open array-values array-close
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -166,8 +166,8 @@ array-close = ws %x5D  ; ]
 
 array = array-open array-values array-close
 
-array-values = ( [ val [ array-sep ] [ ( comment ws-newlines) / ws-newlines ] ) /
-                 ( val array-sep [ ( comment ws-newlines) / ws-newlines ] array-values ] )
+array-values = ( [ val [ array-sep ] [ ( ws-newline comment ws-newlines) / ws-newlines ] ) /
+                 ( val array-sep [ ( ws-newline comment ws-newlines) / ws-newlines ] array-values ] )
 
 array-sep = ws %x2C ws  ; , Comma
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -158,15 +158,16 @@ date-time      = full-date "T" full-time
 
 ;; Array
 
-ws-newline       = *(ws / newline)
+ws-newline       = *( ws / newline )
+ws-newlines      = newline *( ws / newline )
 
 array-open  = %x5B ws-newline  ; [
 array-close = ws %x5D  ; ]
 
 array = array-open array-values array-close
 
-array-values = ( [ val [ array-sep ] [ ( comment newlines) / newlines ] ) /
-                 ( val array-sep [ ( comment newlines) / newlines ] array-values ] )
+array-values = ( [ val [ array-sep ] [ ( comment ws-newlines) / ws-newlines ] ) /
+                 ( val array-sep [ ( comment ws-newlines) / ws-newlines ] array-values ] )
 
 array-sep = ws %x2C ws  ; , Comma
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -6,9 +6,9 @@
 toml = expression *( newline expression )
 expression = (
   ws /
-  ws comment /
-  ws keyval ws [ comment ] /
-  ws table ws [ comment ]
+  ( ws comment ) /
+  ( ws keyval ws [ comment ] ) /
+  ( ws table ws [ comment ] )
 )
 
 ;; Newline
@@ -163,8 +163,8 @@ array-close = ws %x5D  ; ]
 
 array = array-open array-values array-close
 
-array-values = [ val [ array-sep ] [ ( comment newlines) / newlines ] /
-                 val array-sep [ ( comment newlines) / newlines ] array-values ]
+array-values = ( [ val [ array-sep ] [ ( comment newlines) / newlines ] ) /
+                 ( val array-sep [ ( comment newlines) / newlines ] array-values ] )
 
 array-sep = ws %x2C ws  ; , Comma
 
@@ -177,8 +177,8 @@ inline-table-sep   = ws %x2C ws  ; , Comma
 inline-table = inline-table-open inline-table-keyvals inline-table-close
 
 inline-table-keyvals = [ inline-table-keyvals-non-empty ]
-inline-table-keyvals-non-empty = key keyval-sep val /
-                                 key keyval-sep val inline-table-sep inline-table-keyvals-non-empty
+inline-table-keyvals-non-empty = ( key keyval-sep val ) /
+                                 ( key keyval-sep val inline-table-sep inline-table-keyvals-non-empty )
 
 ;; Built-in ABNF terms, reproduced here for clarity
 


### PR DESCRIPTION
RFC 4234 Section 3.5 advises the use of grouping notation rather than "bare" alternation when alternatives consist of multiple rules or literals, e.g. "( int float ) / ( bool char )" instead of "int float / bool char".

I might've gotten the grouping wrong, which just serves to illustrate the importance of using grouping notation.
