### PR TITLE
Add new v0.4.0 compliant implementation in Go

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ note the version tag that your parser supports in your Readme.
 - Dart (@just95) - https://github.com/just95/toml.dart
 - Go (@naoina) - https://github.com/naoina/toml
 - Go (@thompelletier) - https://github.com/pelletier/go-toml
+- Go (@kezhuw) - https://github.com/kezhuw/toml
 - Java (@mwanji) - https://github.com/mwanji/toml4j
 - Node.js/io.js/browser (@BinaryMuse) - https://github.com/BinaryMuse/toml-node
 - Node.js/io.js/browser (@jakwings) - https://github.com/jakwings/toml-j0.4


### PR DESCRIPTION
Compare to other implementations for Go:
- [BurntSushi/toml](https://github.com/BurntSushi/toml) It supports v0.4.0
- [naoina/toml](https://github.com/naoina/toml) Fewer bugs, hopefully. In [my fork of naoina/toml](https://github.com/kezhuw/naoina-toml/commits/master), I fixes two of them, but not got merged yet.
- [pelletier/go-toml](https://github.com/pelletier/go-toml) It uses reflection.

So, it is a v0.4.0 compliant TOML implementation, written using reflection in Go.