### PR TITLE
Fix typos in ABNF grammar file

### DIFF
--- a/toml.abnf
+++ b/toml.abnf
@@ -59,7 +59,7 @@ std-table = std-table-open key *( table-key-sep key) std-table-close
 ;; Array Table
 
 array-table-open  = %x5B.5B ws  ; [[ Double left square bracket
-array-table-close = ws %x5D.5D  ; ]] Double right quare bracket
+array-table-close = ws %x5D.5D  ; ]] Double right square bracket
 
 array-table = array-table-open key *( table-key-sep key) array-table-close
 
@@ -118,15 +118,15 @@ ml-basic-unescaped = %x20-5B / %x5D-10FFFF
 
 ;; Literal String
 
-literal-string = apostraphe *literal-char apostraphe
+literal-string = apostrophe *literal-char apostrophe
 
-apostraphe = %x27 ; ' Apostraphe
+apostrophe = %x27 ; ' Apostrophe
 
 literal-char = %x09 / %x20-26 / %x28-10FFFF
 
 ;; Multiline Literal String
 
-ml-literal-string-delim = apostraphe apostraphe apostraphe
+ml-literal-string-delim = apostrophe apostrophe apostrophe
 ml-literal-string = ml-literal-string-delim ml-literal-body ml-literal-string-delim
 
 ml-literal-body = *( ml-literal-char / newline )


### PR DESCRIPTION
This was impossible to ignore. Sorry.