### PR TITLE
Add TOML-javalib to the list of implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ note the version tag that your parser supports in your Readme.
 - Go (@thompelletier) - https://github.com/pelletier/go-toml
 - Go (@kezhuw) - https://github.com/kezhuw/toml
 - Java (@mwanji) - https://github.com/mwanji/toml4j
+- Java (@TheElectronWill) - https://github.com/TheElectronWill/TOML-javalib
 - Node.js/io.js/browser (@BinaryMuse) - https://github.com/BinaryMuse/toml-node
 - Node.js/io.js/browser (@jakwings) - https://github.com/jakwings/toml-j0.4
 - OCaml (@mackwic) https://github.com/mackwic/to.ml


### PR DESCRIPTION
I've just released the first working (stable) release of [my TOML library](https://github.com/TheElectronWill/TOML-javalib), therefore I add it there.