### PR TITLE
Add test for nesting within arrays of tables

### DIFF
--- a/tests/fruit.toml
+++ b/tests/fruit.toml
@@ -1,0 +1,13 @@
+[[fruit.blah]]
+  name = "apple"
+
+  [fruit.blah.physical]
+    color = "red"
+    shape = "round"
+
+[[fruit.blah]]
+  name = "banana"
+
+  [fruit.blah.physical]
+    color = "yellow"
+    shape = "bent"

--- a/tests/fruit.yaml
+++ b/tests/fruit.yaml
@@ -1,0 +1,13 @@
+fruit: 
+  blah: 
+    - 
+      name: "apple"
+      physical: 
+        color: "red"
+        shape: "round"
+    - 
+      name: "banana"
+      physical: 
+        color: "yellow"
+        shape: "bent"
+


### PR DESCRIPTION
By my reading, this should be valid, and `tomlv` accepts it:

```
$ tomlv -types fruit.toml                                                                                                                         ~
    fruit.blah                         ArrayHash
        fruit.blah.name                String
        fruit.blah.physical            Hash
            fruit.blah.physical.color  String
            fruit.blah.physical.shape  String
    fruit.blah                         ArrayHash
        fruit.blah.name                String
        fruit.blah.physical            Hash
            fruit.blah.physical.color  String
            fruit.blah.physical.shape  String
```

However, I am proposing it as a new test because htoml _doesn't_ accept this (https://github.com/cies/htoml/issues/16), so I want to clarify the issue.
