### PR TITLE
Allow accidental whitespace between backslash and newline.

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,13 +207,11 @@ str2 = "Roses are red\nViolets are blue"
 str3 = "Roses are red\r\nViolets are blue"
 ```
 
-For writing long strings without introducing extraneous whitespace, end a line
-with a `\`.  The `\` will be trimmed along with all whitespace (including
-newlines) up to the next non-whitespace character or closing delimiter.
-Accidental whitespace between the backslash and newline is allowed (even though
-it will create an otherwise invalid backslash-space or backslash-tab) and will
-be trimmed. All of the escape sequences that are valid for basic strings are
-also valid for multi-line basic strings.
+For writing long strings without introducing extraneous whitespace, use a "line
+ending backslash". When the last non-whitespace character on a line is a `\`, it
+will be trimmed along with all whitespace (including newlines) up to the next
+non-whitespace character or closing delimiter. All of the escape sequences that
+are valid for basic strings are also valid for multi-line basic strings.
 
 ```toml
 # The following strings are byte-for-byte equivalent:

--- a/README.md
+++ b/README.md
@@ -208,12 +208,12 @@ str3 = "Roses are red\r\nViolets are blue"
 ```
 
 For writing long strings without introducing extraneous whitespace, end a line
-with a `\`. The `\` will be trimmed along with all whitespace (including
-newlines) up to the next non-whitespace character or closing delimiter. If the
-first characters after the opening delimiter are a backslash and a newline, then
-they will both be trimmed along with all whitespace and newlines up to the next
-non-whitespace character or closing delimiter. All of the escape sequences that
-are valid for basic strings are also valid for multi-line basic strings.
+with a `\`.  The `\` will be trimmed along with all whitespace (including
+newlines) up to the next non-whitespace character or closing delimiter.
+Accidental whitespace between the backslash and newline is allowed (even though
+it will create an otherwise invalid backslash-space or backslash-tab) and will
+be trimmed. All of the escape sequences that are valid for basic strings are
+also valid for multi-line basic strings.
 
 ```toml
 # The following strings are byte-for-byte equivalent:

--- a/toml.abnf
+++ b/toml.abnf
@@ -123,7 +123,7 @@ ml-basic-string = ml-basic-string-delim ml-basic-body ml-basic-string-delim
 
 ml-basic-string-delim = 3quotation-mark
 
-ml-basic-body = *( ml-basic-char / newline / ( escape newline ))
+ml-basic-body = *( ml-basic-char / newline / ( escape ws newline ))
 ml-basic-char = ml-basic-unescaped / escaped
 ml-basic-unescaped = %x20-5B / %x5D-10FFFF
 


### PR DESCRIPTION
This change allows (presumably accidental) whitespace to exist in multi-line basic strings between a line-ending backslash and the following newline. See #436 for more context.