### PR TITLE
Improve literal strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,13 +250,18 @@ regex    = '<\i\c*\s*>'
 regex2   = 'I [dw]on't need \d{2} apples'
 ```
 
-Since there is no escaping, there is no way to write a single quote inside a
-literal string enclosed by single quotes. Luckily, TOML supports a multi-line
-version of literal strings that solves this problem. **Multi-line literal
-strings** are surrounded by three single quotes on each side and allow newlines.
-Like literal strings, there is no escaping whatsoever. A newline immediately
-following the opening delimiter will be trimmed. All other content between the
-delimiters is interpreted as-is without modification.
+While there is no escaping, it is still possible to include single quotes
+by typing them twice:
+
+```toml
+quotetoml = 'Tom''s Obvious, Minimal Language'
+```
+
+**Multi-line literal strings** begin with three single quotes, optional
+whitespace, and newline. Optional whitespace and newline is trimmed by the
+parser. End of multi-line literal string is marked by a line containing only
+three single quotes. All other content between the delimiters is interpreted
+as-is without modification.
 
 ```toml
 lines  = '''
@@ -264,6 +269,21 @@ The first newline is
 trimmed in literal strings.
    All other whitespace
    is preserved.
+Single quotes are preserved:
+   Multi-line literal strings begin with ''' and end with '''
+Here is the end:
+'''
+```
+
+As multi-line literal strings always span at least two lines, it is
+impossible to confuse them with single-line literal strings:
+
+```toml
+# The following three strings are byte-for-byte equivalent:
+quote1 = "'single quotes all the way down'"
+quote2 = '''single quotes all the way down'''
+quote3 = '''
+'single quotes all the way down'
 '''
 ```
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ delimiters is interpreted as-is without modification.
 regex2 = '''I [dw]on't need \d{2} apples'''
 lines  = '''
 The first newline is
-trimmed in raw strings.
+trimmed in literal strings.
    All other whitespace
    is preserved.
 '''

--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ winpath  = 'C:\Users\nodejs\templates'
 winpath2 = '\\ServerX\admin$\system32\'
 quoted   = 'Tom "Dubs" Preston-Werner'
 regex    = '<\i\c*\s*>'
+regex2   = 'I [dw]on't need \d{2} apples'
 ```
 
 Since there is no escaping, there is no way to write a single quote inside a
@@ -258,7 +259,6 @@ following the opening delimiter will be trimmed. All other content between the
 delimiters is interpreted as-is without modification.
 
 ```toml
-regex2 = '''I [dw]on't need \d{2} apples'''
 lines  = '''
 The first newline is
 trimmed in literal strings.


### PR DESCRIPTION
This change makes it possible to include literal string markers into literal strings by duplicating them. The change is not backwards compatible because I had to forbid multi-line literal strings that span single line. But who thinks single-line multi-line literal strings are obvious anyway? They can be replaced with real multi-line strings simply by inserting a newline at the beginning.

I have thought about escaping ''' line by repeating it too, but for now it is impossible, because these lines may have different newlines and it is not obvious what to do in this case. Otherwise, this change is desirable, as it would allow, for example, to embed any TOML document in a string simply by repeating any line that contains only '''.

Please read third commit message for more details.

ABNF is not updated yet, will do it if feedback is positive.