### PR TITLE
Clarify that keys are always strings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,10 +120,12 @@ key = "value"
 
 Keys may be either bare or quoted. **Bare keys** may only contain letters,
 numbers, underscores, and dashes (`A-Za-z0-9_-`). Note that bare keys are
-allowed to be composed of only digits, e.g. `1234`. **Quoted keys** follow the
-exact same rules as either basic strings or literal strings and allow you to use
-a much broader set of key names. Best practice is to use bare keys except when
-absolutely necessary.
+allowed to be composed of only digits, e.g. `1234`, but are always interpreted
+as strings. **Quoted keys** follow the exact same rules as either basic strings
+or literal strings and allow you to use a much broader set of key names. Best
+practice is to use bare keys except when absolutely necessary.
+
+
 
 ```toml
 key = "value"


### PR DESCRIPTION
What
===
Add clarification that bare keys are always strings, even if they are
only digits.

Why
===
While it's implied that keys are all the same type and are of the string
type, it's not explicit in the specification. In some libraries using
the specification it's been suggested that bare keys could be
interpreted as other types, e.g. integers, but this is problematic as
most languages cannot effectively handle mixed type keys on maps. We
should be explicit that keys are only strings.

Ref: BurntSushi/toml#154