### PR TITLE
Allow empty quoted key

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,15 @@ All table names must be non-empty.
 [.]    # INVALID
 ```
 
+But an empty quoted name is allowed (though discouraged).
+
+```toml
+
+[a.""]   # VALID but discouraged
+[a.''.c] # VALID but discouraged
+[""]     # VALID but discouraged
+```
+
 Inline Table
 ------------
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -43,9 +43,8 @@ comment = comment-start-symbol *non-eol
 
 keyval = key keyval-sep val
 
-key = unquoted-key / quoted-key
+key = unquoted-key / basic-string / literal-string
 unquoted-key = 1*( ALPHA / DIGIT / %x2D / %x5F ) ; A-Z / a-z / 0-9 / - / _
-quoted-key = quotation-mark 1*basic-char quotation-mark ; See Basic Strings
 
 keyval-sep = ws %x3D ws ; =
 


### PR DESCRIPTION
As stated in README.md:
>A bare key must be non-empty, but an empty quoted key is allowed (though discouraged).
```toml
= "no key name"  # INVALID
"" = "blank"     # VALID but discouraged
'' = 'blank'     # VALID but discouraged
```