### PR TITLE
Allow multiple newlines and comments in multiline arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,9 +435,10 @@ arr5 = [ [ 1, 2 ], ["a", "b", "c"] ]
 arr6 = [ 1, 2.0 ] # INVALID
 ```
 
-Arrays can also be multiline. So in addition to ignoring whitespace, arrays also
-ignore newlines, and comments before those newlines, between the brackets.
-Terminating commas (also called trailing commas) are ok before the closing bracket.
+Arrays can also be multiline. Terminating commas (also called trailing commas)
+are ok after the last value of the array. Multiline arrays ignore whitespace
+everywhere between the brackets. There can be an arbitary number of newlines and
+comments before a value and before the closing bracket.
 
 ```toml
 arr7 = [

--- a/README.md
+++ b/README.md
@@ -436,9 +436,8 @@ arr6 = [ 1, 2.0 ] # INVALID
 ```
 
 Arrays can also be multiline. Terminating commas (also called trailing commas)
-are ok after the last value of the array. Multiline arrays ignore whitespace
-everywhere between the brackets. There can be an arbitary number of newlines and
-comments before a value and before the closing bracket.
+are ok after the last value of the array. There can be an arbitary number of
+newlines and comments before a value and before the closing bracket.
 
 ```toml
 arr7 = [

--- a/toml.abnf
+++ b/toml.abnf
@@ -187,18 +187,17 @@ local-time = partial-time
 
 ;; Array
 
-array = array-open array-values array-close
+array = array-open ws-comment-newline [ array-values ] array-close
 
-array-open  = %x5B ws-newline  ; [
-array-close = ws-newline %x5D  ; ]
+array-open =  %x5B ; [
+array-close = %x5D ; ]
 
-array-values = [ ( val array-sep [ ( ws-newline comment ws-newlines) / ws-newlines ] array-values ) /
-                 ( val [ array-sep ] [ ( ws-newline comment ws-newlines ) ] ) ]
+array-values =  val ws array-sep ws-comment-newline array-values
+array-values =/ val ws [ array-sep ] ws-comment-newline
 
-array-sep = ws %x2C ws  ; , Comma
+array-sep = %x2C  ; , Comma
 
-ws-newline       = *( wschar / newline )
-ws-newlines      = newline *( wschar / newline )
+ws-comment-newline = *( wschar / [ comment ] newline )
 
 ;; Inline Table
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -187,13 +187,13 @@ local-time = partial-time
 
 ;; Array
 
-array = array-open ws-comment-newline [ array-values ] array-close
+array = array-open [ array-values ] ws-comment-newline array-close
 
 array-open =  %x5B ; [
 array-close = %x5D ; ]
 
-array-values =  val ws array-sep ws-comment-newline array-values
-array-values =/ val ws [ array-sep ] ws-comment-newline
+array-values =  ws-comment-newline val ws array-sep array-values
+array-values =/ ws-comment-newline val ws [ array-sep ]
 
 array-sep = %x2C  ; , Comma
 


### PR DESCRIPTION
Closes #487
Closes #458
Closes #448

This is a modification to allow an arbitrary number of comments and newline in multiline arrays, instead of a fairly inconsistent format as currently specified.
