### PR TITLE
Zeros (int and float) cannot have have a sign (+ or -).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## HEAD
 
+* Specify that zeros (Integer 0 and float 0.0) cannot have a sign (+ or -).
 * Rename Datetime to Offset Date-Time.
 * Add Local Date-Time.
 * Add Local Date.
@@ -14,7 +15,7 @@
 * Clarify that keys are always strings.
 * Clarify that you cannot use array-of-table to append to a static array.
 * Clarify that a TOML file must be a valid UTF-8 document.
-* Clarify valid Array values.
+* Clarify what are valid Array values.
 * Clarify that literal strings can be table keys.
 * Clarify that at least millisecond precision expected for Date-Time and Time.
 * Clarify that comments are OK in multiline arrays.

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Integer
 -------
 
 Integers are whole numbers. Positive numbers may be prefixed with a plus sign.
-Negative numbers are prefixed with a minus sign.
+Negative numbers are prefixed with a minus sign. Zeros cannot have a sign.
 
 ```toml
 int1 = +99
@@ -309,7 +309,7 @@ Float
 A float consists of an integer part (which follows the same rules as integer
 values) followed by a fractional part and/or an exponent part. If both a
 fractional part and exponent part are present, the fractional part must precede
-the exponent part.
+the exponent part. Zeros cannot have a sign.
 
 ```toml
 # fractional

--- a/toml.abnf
+++ b/toml.abnf
@@ -106,12 +106,14 @@ ml-literal-char = %x09 / %x20-10FFFF
 
 ;; Integer
 
-integer = [ minus / plus ] int
+integer =  [ minus / plus ] non-zero
+integer =/ digit0
 
 minus = %x2D                       ; -
 plus = %x2B                        ; +
 
-int = DIGIT / digit1-9 1*( DIGIT / underscore DIGIT )
+non-zero = digit1-9 *( DIGIT / underscore DIGIT )
+digit0   = %x30                    ; 0
 digit1-9 = %x31-39                 ; 1-9
 underscore = %x5F                  ; _
 


### PR DESCRIPTION
Replacement for #492 with a few wording tweaks and extended to Floats as well.