### PR TITLE
Add non-finite floats and clarify signed zeros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## HEAD
 
-* Add non-finite float values (+inf, inf, -inf, nan)
+* Add special float values (inf, nan)
 * Rename Datetime to Offset Date-Time.
 * Add Local Date-Time.
 * Add Local Date.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## HEAD
 
+* Add non-finite float values (+inf, inf, -inf, nan)
 * Rename Datetime to Offset Date-Time.
 * Add Local Date-Time.
 * Add Local Date.
@@ -18,6 +19,7 @@
 * Clarify that literal strings can be table keys.
 * Clarify that at least millisecond precision expected for Date-Time and Time.
 * Clarify that comments are OK in multiline arrays.
+* Clarify that +0, -0, +0.0, and -0.0 are valid and what they mean.
 * TOML has a logo!
 
 ## 0.4.0 / 2015-02-12

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ identical to an unprefixed zero. Hex, octal, and binary forms are not allowed.
 Float
 -----
 
-Floats should be implemented as 64-bit IEEE 754 values.
+Floats should be implemented as IEEE 754 binary64 values.
 
 A float consists of an integer part (which follows the same rules as integer
 values) followed by a fractional part and/or an exponent part. If both a
@@ -347,7 +347,7 @@ Non-finite float values can also be expressed. They are always lowercase.
 nf1 = +inf # positive infinity
 nf2 = inf  # positive infinity
 nf3 = -inf # negative infinity
-nf4 = nan  # not a number
+nf4 = nan  # not a number; actual sNaN/qNaN value is implementation specific
 ```
 
 Boolean

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ flt8 = 9_224_617.445_991_228_313
 
 Float values `-0.0` and `+0.0` are valid and should map according to IEEE 754.
 
-Non-finite float values can also be expressed. They are always lowercase.
+Special float values can also be expressed. They are always lowercase.
 
 ```toml
 nf1 = +inf # positive infinity

--- a/README.md
+++ b/README.md
@@ -296,15 +296,16 @@ int6 = 5_349_221
 int7 = 1_2_3_4_5     # VALID but discouraged
 ```
 
-Leading zeros are not allowed. Hex, octal, and binary forms are not allowed.
-Values such as "infinity" and "not a number" that cannot be expressed as a
-series of digits are not allowed.
+Leading zeros are not allowed. Integer values `-0` and `+0` are valid and
+identical to an unprefixed zero. Hex, octal, and binary forms are not allowed.
 
 64 bit (signed long) range expected (−9,223,372,036,854,775,808 to
 9,223,372,036,854,775,807).
 
 Float
 -----
+
+Floats should be implemented as 64-bit IEEE 754 values.
 
 A float consists of an integer part (which follows the same rules as integer
 values) followed by a fractional part and/or an exponent part. If both a
@@ -338,7 +339,16 @@ underscore must be surrounded by at least one digit.
 flt8 = 9_224_617.445_991_228_313
 ```
 
-64-bit (double) precision expected.
+Float values `-0.0` and `+0.0` are valid and should map according to IEEE 754.
+
+Non-finite float values can also be expressed. They are always lowercase.
+
+```toml
+nf1 = +inf # positive infinity
+nf2 = inf  # positive infinity
+nf3 = -inf # negative infinity
+nf4 = nan  # not a number
+```
 
 Boolean
 -------

--- a/README.md
+++ b/README.md
@@ -344,10 +344,15 @@ Float values `-0.0` and `+0.0` are valid and should map according to IEEE 754.
 Special float values can also be expressed. They are always lowercase.
 
 ```toml
-nf1 = +inf # positive infinity
-nf2 = inf  # positive infinity
-nf3 = -inf # negative infinity
-nf4 = nan  # not a number; actual sNaN/qNaN value is implementation specific
+# infinity
+sf1 = inf  # positive infinity
+sf2 = +inf # positive infinity
+sf3 = -inf # negative infinity
+
+# not a number
+sf4 = nan  # actual sNaN/qNaN encoding is implementation specific
+sf5 = +nan # same as `nan`
+sf6 = -nan # valid, actual encoding is implementation specific
 ```
 
 Boolean

--- a/toml.abnf
+++ b/toml.abnf
@@ -117,7 +117,7 @@ underscore = %x5F                  ; _
 
 ;; Float
 
-float =  integer ( frac / ( frac exp ) / exp )
+float = integer ( exp / frac [ exp ] )
 float =/ non-finite
 
 frac = decimal-point zero-prefixable-int

--- a/toml.abnf
+++ b/toml.abnf
@@ -126,7 +126,7 @@ zero-prefixable-int = DIGIT *( DIGIT / underscore DIGIT )
 
 exp = "e" integer
 
-special-float = ( [ minus / plus ] inf ) / nan
+special-float = [ minus / plus ] ( inf / nan )
 inf = %x69.6e.66  ; inf
 nan = %x6e.61.6e  ; nan
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -118,7 +118,7 @@ underscore = %x5F                  ; _
 ;; Float
 
 float = integer ( exp / frac [ exp ] )
-float =/ non-finite
+float =/ special-float
 
 frac = decimal-point zero-prefixable-int
 decimal-point = %x2E               ; .
@@ -126,7 +126,7 @@ zero-prefixable-int = DIGIT *( DIGIT / underscore DIGIT )
 
 exp = "e" integer
 
-non-finite = ( [ minus / plus ] inf ) / nan
+special-float = ( [ minus / plus ] inf ) / nan
 inf = %x69.6e.66  ; inf
 nan = %x6e.61.6e  ; nan
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -117,13 +117,18 @@ underscore = %x5F                  ; _
 
 ;; Float
 
-float = integer ( frac / ( frac exp ) / exp )
+float =  integer ( frac / ( frac exp ) / exp )
+float =/ non-finite
 
 frac = decimal-point zero-prefixable-int
 decimal-point = %x2E               ; .
 zero-prefixable-int = DIGIT *( DIGIT / underscore DIGIT )
 
 exp = "e" integer
+
+non-finite = ( [ minus / plus ] inf ) / nan
+inf = %x69.6e.66  ; inf
+nan = %x6e.61.6e  ; nan
 
 ;; Boolean
 


### PR DESCRIPTION
Closes #389.

This adds support for non-finite float values (`-inf`, `inf`, `+inf`, `nan`) and clarifies that signed zeros (integer and float) are valid and what they mean.