### PR TITLE
Add hex, octal, and binary integer formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## HEAD
 
+* Add hex, octal, and binary integer formats.
 * Add special float values (inf, nan)
 * Rename Datetime to Offset Date-Time.
 * Add Local Date-Time.

--- a/README.md
+++ b/README.md
@@ -299,17 +299,16 @@ int7 = 1_2_3_4_5     # VALID but discouraged
 Leading zeros are not allowed. Integer values `-0` and `+0` are valid and
 identical to an unprefixed zero.
 
-Integer values may also be expressed in hexadecimal, octal, or binary. Hex
-values are case insensitive. Leading zeros are allowed. Underscores are allowed
-between digits (but not between the prefix and the value).
+Non-negative integer values may also be expressed in hexadecimal, octal, or
+binary. In these formats, leading zeros are allowed (after the prefix). Hex
+values are case insensitive. Underscores are allowed between digits (but not
+between the prefix and the value).
 
 ```toml
 # hexadecimal with prefix `0x`
 hex1 = 0xDEADBEEF
 hex2 = 0xdeadbeef
 hex3 = 0xdead_beef
-hex4 = +0xDEADBEEF # same as above
-hex5 = -0xDEADBEEF # negative of above
 
 # octal with prefix `0o`
 oct1 = 0o01234567

--- a/README.md
+++ b/README.md
@@ -297,7 +297,27 @@ int7 = 1_2_3_4_5     # VALID but discouraged
 ```
 
 Leading zeros are not allowed. Integer values `-0` and `+0` are valid and
-identical to an unprefixed zero. Hex, octal, and binary forms are not allowed.
+identical to an unprefixed zero.
+
+Integer values may also be expressed in hexadecimal, octal, or binary. Hex
+values are case insensitive. Leading zeros are allowed. Underscores are allowed
+between digits (but not between the prefix and the value).
+
+```toml
+# hexadecimal with prefix `0x`
+hex1 = 0xDEADBEEF
+hex2 = 0xdeadbeef
+hex3 = 0xdead_beef
+hex4 = +0xDEADBEEF # same as above
+hex5 = -0xDEADBEEF # negative of above
+
+# octal with prefix `0o`
+oct1 = 0o01234567
+oct2 = 0o755 # useful for Unix file permissions
+
+# binary with prefix `0b`
+bin1 = 0b11010110
+```
 
 64 bit (signed long) range expected (−9,223,372,036,854,775,808 to
 9,223,372,036,854,775,807).

--- a/toml.abnf
+++ b/toml.abnf
@@ -106,25 +106,35 @@ ml-literal-char = %x09 / %x20-10FFFF
 
 ;; Integer
 
-integer = [ minus / plus ] int
+integer = [ minus / plus ] ( dec-int / hex-int / oct-int / bin-int )
 
 minus = %x2D                       ; -
 plus = %x2B                        ; +
-
-int = DIGIT / digit1-9 1*( DIGIT / underscore DIGIT )
-digit1-9 = %x31-39                 ; 1-9
 underscore = %x5F                  ; _
+digit1-9 = %x31-39                 ; 1-9
+digit0-7 = %x30-37                 ; 0-7
+digit0-1 = %x30-31                 ; 0-1
+
+hex-prefix = %x30.78               ; 0x
+oct-prefix = %x30.6f               ; 0o
+bin-prefix = %x30.62               ; 0b
+
+dec-int = DIGIT / digit1-9 1*( DIGIT / underscore DIGIT )
+hex-int = hex-prefix HEXDIG *( HEXDIG / underscore HEXDIG )
+oct-int = oct-prefix digit0-7 *( digit0-7 / underscore digit0-7 )
+bin-int = bin-prefix digit0-1 *( digit0-1 / underscore digit0-1 )
 
 ;; Float
 
-float = integer ( exp / frac [ exp ] )
+float = float-int-part ( exp / frac [ exp ] )
 float =/ special-float
 
+float-int-part = [ minus / plus ] dec-int
 frac = decimal-point zero-prefixable-int
 decimal-point = %x2E               ; .
 zero-prefixable-int = DIGIT *( DIGIT / underscore DIGIT )
 
-exp = "e" integer
+exp = "e" float-int-part
 
 special-float = [ minus / plus ] ( inf / nan )
 inf = %x69.6e.66  ; inf

--- a/toml.abnf
+++ b/toml.abnf
@@ -106,7 +106,7 @@ ml-literal-char = %x09 / %x20-10FFFF
 
 ;; Integer
 
-integer = [ minus / plus ] ( dec-int / hex-int / oct-int / bin-int )
+integer = dec-int / hex-int / oct-int / bin-int
 
 minus = %x2D                       ; -
 plus = %x2B                        ; +
@@ -119,7 +119,9 @@ hex-prefix = %x30.78               ; 0x
 oct-prefix = %x30.6f               ; 0o
 bin-prefix = %x30.62               ; 0b
 
-dec-int = DIGIT / digit1-9 1*( DIGIT / underscore DIGIT )
+dec-int = [ minus / plus ] unsigned-dec-int
+unsigned-dec-int = DIGIT / digit1-9 1*( DIGIT / underscore DIGIT )
+
 hex-int = hex-prefix HEXDIG *( HEXDIG / underscore HEXDIG )
 oct-int = oct-prefix digit0-7 *( digit0-7 / underscore digit0-7 )
 bin-int = bin-prefix digit0-1 *( digit0-1 / underscore digit0-1 )
@@ -129,7 +131,7 @@ bin-int = bin-prefix digit0-1 *( digit0-1 / underscore digit0-1 )
 float = float-int-part ( exp / frac [ exp ] )
 float =/ special-float
 
-float-int-part = [ minus / plus ] dec-int
+float-int-part = dec-int
 frac = decimal-point zero-prefixable-int
 decimal-point = %x2E               ; .
 zero-prefixable-int = DIGIT *( DIGIT / underscore DIGIT )


### PR DESCRIPTION
Closes #409.

```
# hexadecimal with prefix `0x`
hex1 = 0xDEADBEEF
hex2 = 0xdeadbeef
hex3 = 0xdead_beef

# octal with prefix `0o`
oct1 = 0o01234567
oct2 = 0o755 # useful for Unix file permissions

# binary with prefix `0b`
bin1 = 0b11010110
```