### PR TITLE
Remove stability warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ By Tom Preston-Werner.
 Latest tagged version:
 [v0.4.0](https://github.com/mojombo/toml/blob/master/versions/en/toml-v0.4.0.md).
 
-Be warned, this spec is still changing a lot. Until it's marked as 1.0, you
-should assume that it is unstable and act accordingly.
-
 Objectives
 ----------
 


### PR DESCRIPTION
Based on the fact that v0.4 has been stable for quite a while now, and the discussions [here](https://github.com/toml-lang/toml/issues/330) seem to suggest that v1.0 is near, I think it makes sense to remove this warning already.