### PR TITLE
Fix the exponent part of ABNF

### DIFF
--- a/toml.abnf
+++ b/toml.abnf
@@ -138,7 +138,7 @@ frac = decimal-point zero-prefixable-int
 decimal-point = %x2E               ; .
 zero-prefixable-int = DIGIT *( DIGIT / underscore DIGIT )
 
-exp = "e" float-int-part
+exp = ("e" / "E") float-int-part
 
 special-float = [ minus / plus ] ( inf / nan )
 inf = %x69.6e.66  ; inf


### PR DESCRIPTION
The specs clearly state that an exponent part may start with an "e" or "E" character but the ABNF disallows "E". This change resolves the conflict between them.