### PR TITLE
Newline-Delimited Inner Tables

### DIFF
--- a/toml.abnf
+++ b/toml.abnf
@@ -51,7 +51,8 @@ dotted-key = simple-key 1*( dot-sep simple-key )
 dot-sep   = ws %x2E ws  ; . Period
 keyval-sep = ws %x3D ws ; =
 
-val = string / boolean / array / inline-table / date-time / float / integer
+val = string / boolean / array / table-val / date-time / float / integer
+table-val = inline-table / inner-table
 
 ;; String
 
@@ -210,6 +211,17 @@ std-table = std-table-open key std-table-close
 
 std-table-open  = %x5B ws     ; [ Left square bracket
 std-table-close = ws %x5D     ; ] Right square bracket
+
+;; Newline-Delimited Inner Table
+
+inner-table = inner-table-open inner-table-keyvals inner-table-close
+
+inner-table-open  = %x7B ws [comment] newline    ; { at end of line
+inner-table-close = ws %x7D                      ; } at start of line
+
+inner-table-keyvals = *( inner-table-keyval newline )
+inner-table-keyval  =  ws [ comment ]
+inner-table-keyval  =/ ws keyval ws [ comment ]
 
 ;; Inline Table
 


### PR DESCRIPTION
This PR defines a new inner table value syntax. It is compatible with TOML v0.5.0 and the standard to date, and I hope to include it before the release of v1.0. This closes discussion on #525, though further comments are invited.

```
[std]
key1 = "std.value1"
key2 = "std.value2"

# An inner table may be defined anywhere that an inline table is allowed.
# To open the table, end a line with "{". Comments and whitespace are optional.
table3 = {
    # Key/value pairs are separated with newlines. Commas are not permitted.
    subkeyA = "std.table3.valueA"
    subkeyB = "std.table3.valueB"
    subkeyC = "std.table3.valueC"

    # Inline table values and dotted key paths are allowed. Nested inner tables
    # are also permitted, but ought to be discouraged.
    subZ = {A = "std.table3.subZ.valueA", keyB = "std.table3.subZ.valueB"}
    subkey_0.subsubkey_0 = "std.table3.subkey_0.subsubvalue_0"
}
# To close the table, begin a line with "}", with optional whitespace.

# Assignments to the standard table may resume afterwards.
key4 = "std.value4"
```

`README.md` still needs to be updated, and I would like to include some useful
examples in appropriate places.