### PR TITLE
Add `MIME Type` to table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Table of contents
 - [Inline Table](#user-content-inline-table)
 - [Array of Tables](#user-content-array-of-tables)
 - [Filename Extension](#user-content-filename-extension)
+- [MIME Type](#user-content-mime-type)
 - [Comparison with Other Formats](#user-content-comparison-with-other-formats)
 - [Get Involved](#user-content-get-involved)
 - [Wiki](#user-content-wiki)


### PR DESCRIPTION
Since all the other contents have links, I thought that it would be good to add `MIME Type`. Thanks!