### PR TITLE
Support standalone escape in multiline strings

### DIFF
--- a/toml.abnf
+++ b/toml.abnf
@@ -84,9 +84,9 @@ ml-basic-string = ml-basic-string-delim ml-basic-body ml-basic-string-delim
 
 ml-basic-string-delim = 3quotation-mark
 
-ml-basic-body = *( ml-basic-char / newline / ( escape ws newline ) )
+ml-basic-body = *( ml-basic-char / newline )
 ml-basic-char = ml-basic-unescaped / escaped
-ml-basic-unescaped = %x20-5B / %x5D-7E / %x80-10FFFF
+ml-basic-unescaped = %x20-5B / %x5C-7E / %x80-10FFFF
 
 ;; Literal String
 


### PR DESCRIPTION
An escape was not allowed in a multi line string
except as part of an escape sequence or a "line ending backslash"

So the following would be illegal according to this grammar:
```
myPattern = """\d{2}"""
```
was this the intent?

I suggest removing the specific syntax for the "line ending backslash"
because it is already included in the defined grammar (all backslash, ws and NL are  already allowed inside a multi-line string).
One could consider "line ending backslash" as the semantic behavior  that should be implemented in a compiler
rather than the syntactic definition that a parser is responsible for reading.