### PR TITLE
Do not allow surrogate code points in ABNF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* None.
+* Disallow UTF-16 surrogate code points in grammar (U+D800 - U+DFFF).
 
 ## 0.5.0 / 2018-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-* Disallow UTF-16 surrogate code points in grammar (U+D800 - U+DFFF).
+* Clarify in ABNF that UTF-16 surrogate code points (U+D800 - U+DFFF) are not
+  allowed in strings or comments.
 
 ## 0.5.0 / 2018-07-11
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -32,8 +32,8 @@ newline =/ %x0D.0A  ; CRLF
 ;; Comment
 
 comment-start-symbol = %x23 ; #
-non-eol =  %x09
-non-eol =/ %x20-10FFFF
+non-ascii = %x80-D7FF / %xE000-10FFFF
+non-eol = %x09 / %x20-7F / non-ascii
 
 comment = comment-start-symbol *non-eol
 
@@ -64,7 +64,7 @@ basic-string = quotation-mark *basic-char quotation-mark
 quotation-mark = %x22            ; "
 
 basic-char = basic-unescaped / escaped
-basic-unescaped = %x20-21 / %x23-5B / %x5D-7E / %x80-10FFFF
+basic-unescaped = %x20-21 / %x23-5B / %x5D-7E / non-ascii
 escaped = escape escape-seq-char
 
 escape = %x5C                   ; \
@@ -86,7 +86,7 @@ ml-basic-string-delim = 3quotation-mark
 
 ml-basic-body = *( ml-basic-char / newline / ( escape ws newline ) )
 ml-basic-char = ml-basic-unescaped / escaped
-ml-basic-unescaped = %x20-5B / %x5D-7E / %x80-10FFFF
+ml-basic-unescaped = %x20-5B / %x5D-7E / non-ascii
 
 ;; Literal String
 
@@ -94,7 +94,7 @@ literal-string = apostrophe *literal-char apostrophe
 
 apostrophe = %x27 ; ' apostrophe
 
-literal-char = %x09 / %x20-26 / %x28-7E / %x80-10FFFF
+literal-char = %x09 / %x20-26 / %x28-7E / non-ascii
 
 ;; Multiline Literal String
 
@@ -103,7 +103,7 @@ ml-literal-string = ml-literal-string-delim ml-literal-body ml-literal-string-de
 ml-literal-string-delim = 3apostrophe
 
 ml-literal-body = *( ml-literal-char / newline )
-ml-literal-char = %x09 / %x20-7E / %x80-10FFFF
+ml-literal-char = %x09 / %x20-7E / non-ascii
 
 ;; Integer
 


### PR DESCRIPTION
This is more a suggestion than a request.

I noticed that the current ABNF grammar allows [UTF-16 surrogate code points](https://unicode.org/glossary/#surrogate_code_point) (0xD800 - 0xDFFF) in strings and comments. This seems inconsistent, because it is invalid to insert these code points via escape sequences (e.g. \uD800).

This commit excludes the surrogate range. Because this affects five separate rules, I added a reusable rule `non-ascii`, to reduce redundancy.