### PR TITLE
Re #571, allow raw tabs in basic and MLB strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Clarify in ABNF that UTF-16 surrogate code points (U+D800 - U+DFFF) are not
   allowed in strings or comments.
+* Allow raw tab characters in basic strings and multi-line basic strings.
 
 ## 0.5.0 / 2018-07-11
 

--- a/README.md
+++ b/README.md
@@ -314,9 +314,10 @@ str3 = """\
 ```
 
 Any Unicode character may be used except those that must be escaped: backslash
-and the control characters other than tab (U+0000 to U+0008, U+000A to U+001F,
-U+007F). Quotation marks need not be escaped unless their presence would create
-a premature closing delimiter.
+and the control characters other than tab, line feed, and carriage return
+(U+0000 to U+0008, U+000B, U+000C, U+000E to U+001F, U+007F). Quotation marks
+need not be escaped unless their presence would create a premature closing
+delimiter.
 
 If you're a frequent specifier of Windows paths or regular expressions, then
 having to escape backslashes quickly becomes tedious and error prone. To help,

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ multi-line literal. All strings must contain only valid UTF-8 characters.
 
 **Basic strings** are surrounded by quotation marks. Any Unicode character may
 be used except those that must be escaped: quotation mark, backslash, and the
-control characters (U+0000 to U+001F, U+007F).
+control characters other than tab (U+0000 to U+0008, U+000A to U+001F, U+007F).
 
 ```toml
 str = "I'm a string. \"You can quote me\". Name\tJos\u00E9\nLocation\tSF."
@@ -314,8 +314,9 @@ str3 = """\
 ```
 
 Any Unicode character may be used except those that must be escaped: backslash
-and the control characters (U+0000 to U+001F, U+007F). Quotation marks need not
-be escaped unless their presence would create a premature closing delimiter.
+and the control characters other than tab (U+0000 to U+0008, U+000A to U+001F,
+U+007F). Quotation marks need not be escaped unless their presence would create
+a premature closing delimiter.
 
 If you're a frequent specifier of Windows paths or regular expressions, then
 having to escape backslashes quickly becomes tedious and error prone. To help,

--- a/toml.abnf
+++ b/toml.abnf
@@ -64,7 +64,7 @@ basic-string = quotation-mark *basic-char quotation-mark
 quotation-mark = %x22            ; "
 
 basic-char = basic-unescaped / escaped
-basic-unescaped = %x20-21 / %x23-5B / %x5D-7E / non-ascii
+basic-unescaped = %x09 / %x20-21 / %x23-5B / %x5D-7E / non-ascii
 escaped = escape escape-seq-char
 
 escape = %x5C                   ; \
@@ -86,7 +86,7 @@ ml-basic-string-delim = 3quotation-mark
 
 ml-basic-body = *( ml-basic-char / newline / ( escape ws newline ) )
 ml-basic-char = ml-basic-unescaped / escaped
-ml-basic-unescaped = %x20-5B / %x5D-7E / non-ascii
+ml-basic-unescaped = %x09 / %x20-5B / %x5D-7E / non-ascii
 
 ;; Literal String
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -64,7 +64,7 @@ basic-string = quotation-mark *basic-char quotation-mark
 quotation-mark = %x22            ; "
 
 basic-char = basic-unescaped / escaped
-basic-unescaped = %x09 / %x20-21 / %x23-5B / %x5D-7E / non-ascii
+basic-unescaped = wschar / %x21 / %x23-5B / %x5D-7E / non-ascii
 escaped = escape escape-seq-char
 
 escape = %x5C                   ; \

--- a/toml.abnf
+++ b/toml.abnf
@@ -86,7 +86,7 @@ ml-basic-string-delim = 3quotation-mark
 
 ml-basic-body = *( ml-basic-char / newline / ( escape ws newline ) )
 ml-basic-char = ml-basic-unescaped / escaped
-ml-basic-unescaped = %x09 / %x20-5B / %x5D-7E / non-ascii
+ml-basic-unescaped = wschar / %x21-5B / %x5D-7E / non-ascii
 
 ;; Literal String
 


### PR DESCRIPTION
In response to #571, these changes permit the horizontal tab character to be used in both basic strings and multi-line basic strings.