### PR TITLE
Typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Spec
 * TOML is case sensitive.
 * A TOML file must be a valid UTF-8 encoded Unicode document.
 * Whitespace means tab (0x09) or space (0x20).
-* Newline means LF (0x0A) or CRLF (0x0D0A).
+* Newline means LF (0x0A) or CRLF (0x0D).
 
 Comment
 -------

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Spec
 * TOML is case sensitive.
 * A TOML file must be a valid UTF-8 encoded Unicode document.
 * Whitespace means tab (0x09) or space (0x20).
-* Newline means LF (0x0A) or CRLF (0x0D).
+* Newline means LF (0x0A) or CRLF (0x0D 0x0A).
 
 Comment
 -------


### PR DESCRIPTION
`0x0D0A` is the Malayalam Symbol `ഊ` while `0x0D` is `\r`, so I'm calling it a typo.