### PR TITLE
Clarify the use of [a] after [a.b]

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,8 @@ how to do it for you.
 # [x.y] don't
 # [x.y.z] need these
 [x.y.z.w] # for this to work
+
+[x] # defining a super-table afterwards is ok
 ```
 
 Empty tables are allowed and simply have no key/value pairs within them.


### PR DESCRIPTION
It wasn't fully clear from the specs whether or not it is allowed to
create a table [a] explicitly when earlier on in the TOML document the
table [a.b] was created, since that expression creates [a] implicitly.

See: https://github.com/toml-lang/toml/issues/638