### PR TITLE
Clarify that multiple key/vals on 1 line are invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ Datetime, Array, or Inline Table. Unspecified values are invalid.
 key = # INVALID
 ```
 
+There must be a newline after a key/value pair.
+(See [Inline Table](#user-content-inline-table) for exceptions.)
+
+```
+first = "Tom" last = "Preston-Werner" # INVALID
+```
+
 Keys
 ----
 


### PR DESCRIPTION
It wasn't fully clear from the specs whether or not it is allowed
to have multiple Key/Value pairs together on 1 line of a TOML doc.

See: https://github.com/toml-lang/toml/issues/637