### PR TITLE
Clarify: no dotted keys or subtables into inline tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Clarify that inline tables cannot have keys or subtables injected into them.
 * Clarify in ABNF that UTF-16 surrogate code points (U+D800 - U+DFFF) are not
   allowed in strings or comments.
 * Allow raw tab characters in basic strings and multi-line basic strings.

--- a/README.md
+++ b/README.md
@@ -701,7 +701,7 @@ type.name = "pug"
 
 ```
 
-Once inline tables are defined, their values are fully set, and new elements and
+Once inline tables are defined, their values are fully set, and new keys and
 subtables cannot be added to them.
 
 ```toml

--- a/README.md
+++ b/README.md
@@ -701,6 +701,15 @@ type.name = "pug"
 
 ```
 
+Once inline tables are defined, their values are fully set, and new elements and
+subtables cannot be added to them.
+
+```toml
+a = {}
+#a.b = 1  # INVALID
+#[a.b]  # INVALID
+```
+
 Array of Tables
 ---------------
 


### PR DESCRIPTION
This intends to resolve #630, i.e. it clarifies that inline tables are immutable once defined.