### PR TITLE
Correct use of quotation marks in multiline strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Clarify in ABNF how quotes in multi-line basic and multi-line literal strings
+  are allowed to be used.
 * Leading zeroes in exponent parts of floats are permitted.
 * Clarify behavior of tables defined implicitly by dotted keys.
 * Clarify that inline tables are immutable.

--- a/README.md
+++ b/README.md
@@ -412,8 +412,7 @@ trimmed in raw strings.
 ```
 
 You can write 1 or 2 single quotes anywhere within a multi-line literal string,
-but sequences of three or more single quotes within a multi-line literal string
-are not permitted.
+but sequences of three or more single quotes are not permitted.
 
 ```toml
 quot15 = '''Here are fifteen quotation marks: """""""""""""""'''

--- a/README.md
+++ b/README.md
@@ -373,8 +373,8 @@ str4 = """Here are two quotation marks: "". Simple enough."""
 str5 = """Here are three quotation marks: ""\". Still possible."""
 str6 = """Here are fifteen quotation marks: ""\"""\"""\"""\"""\"."""
 
-# "This", she said, "is just a pointless statement."
-str7 = """"This", she said, "is just a pointless statement.""""
+# "This," she said, "is just a pointless statement."
+str7 = """"This," she said, "is just a pointless statement.""""
 ```
 
 If you're a frequent specifier of Windows paths or regular expressions, then

--- a/README.md
+++ b/README.md
@@ -361,9 +361,21 @@ str3 = """\
 
 Any Unicode character may be used except those that must be escaped: backslash
 and the control characters other than tab, line feed, and carriage return
-(U+0000 to U+0008, U+000B, U+000C, U+000E to U+001F, U+007F). Quotation marks
-need not be escaped unless their presence would create a premature closing
-delimiter.
+(U+0000 to U+0008, U+000B, U+000C, U+000E to U+001F, U+007F).
+
+You can write a quotation mark, or two adjacent quotation marks, anywhere
+inside a multi-line basic string without escaping them, as long as they're not
+confused with the closing delimiter. They can also be written just inside the
+delimiters.
+
+```toml
+str4 = """Here are two quotation marks: "". Simple enough."""
+str5 = """Here are three quotation marks: ""\". Still possible."""
+str6 = """Here are fifteen quotation marks: ""\"""\"""\"""\"""\"."""
+
+# "This", she said, "is just a pointless statement."
+str7 = """"This", she said, "is just a pointless statement.""""
+```
 
 If you're a frequent specifier of Windows paths or regular expressions, then
 having to escape backslashes quickly becomes tedious and error prone. To help,
@@ -397,6 +409,17 @@ trimmed in raw strings.
    All other whitespace
    is preserved.
 '''
+```
+
+You can write 1 or 2 single quotes anywhere within a multi-line literal string,
+but sequences of three or more single quotes within a multi-line literal string
+are not permitted.
+
+```toml
+quot15 = '''Here are fifteen quotation marks: """""""""""""""'''
+
+#apos15 = '''Here are fifteen apostrophes: ''''''''''''''''''  # INVALID
+apos15 = "Here are fifteen apostrophes: '''''''''''''''"
 ```
 
 Control characters other than tab are not permitted in a literal string. Thus,

--- a/README.md
+++ b/README.md
@@ -364,13 +364,13 @@ and the control characters other than tab, line feed, and carriage return
 (U+0000 to U+0008, U+000B, U+000C, U+000E to U+001F, U+007F).
 
 You can write a quotation mark, or two adjacent quotation marks, anywhere
-inside a multi-line basic string without escaping them, as long as they're not
-confused with the closing delimiter. They can also be written just inside the
+inside a multi-line basic string. They can also be written just inside the
 delimiters.
 
 ```toml
 str4 = """Here are two quotation marks: "". Simple enough."""
-str5 = """Here are three quotation marks: ""\". Still possible."""
+#str5 = """Here are three quotation marks: """."""  # INVALID
+str5 = """Here are three quotation marks: ""\"."""
 str6 = """Here are fifteen quotation marks: ""\"""\"""\"""\"""\"."""
 
 # "This," she said, "is just a pointless statement."

--- a/README.md
+++ b/README.md
@@ -420,6 +420,9 @@ quot15 = '''Here are fifteen quotation marks: """""""""""""""'''
 
 #apos15 = '''Here are fifteen apostrophes: ''''''''''''''''''  # INVALID
 apos15 = "Here are fifteen apostrophes: '''''''''''''''"
+
+# 'That's still pointless', she said.
+str = ''''That's still pointless', she said.'''
 ```
 
 Control characters other than tab are not permitted in a literal string. Thus,

--- a/README.md
+++ b/README.md
@@ -369,7 +369,7 @@ delimiters.
 
 ```toml
 str4 = """Here are two quotation marks: "". Simple enough."""
-#str5 = """Here are three quotation marks: """."""  # INVALID
+# str5 = """Here are three quotation marks: """."""  # INVALID
 str5 = """Here are three quotation marks: ""\"."""
 str6 = """Here are fifteen quotation marks: ""\"""\"""\"""\"""\"."""
 
@@ -418,7 +418,7 @@ are not permitted.
 ```toml
 quot15 = '''Here are fifteen quotation marks: """""""""""""""'''
 
-#apos15 = '''Here are fifteen apostrophes: ''''''''''''''''''  # INVALID
+# apos15 = '''Here are fifteen apostrophes: ''''''''''''''''''  # INVALID
 apos15 = "Here are fifteen apostrophes: '''''''''''''''"
 
 # 'That's still pointless', she said.

--- a/toml.abnf
+++ b/toml.abnf
@@ -100,11 +100,12 @@ literal-char = %x09 / %x20-26 / %x28-7E / non-ascii
 ;; Multiline Literal String
 
 ml-literal-string = ml-literal-string-delim ml-literal-body ml-literal-string-delim
-
 ml-literal-string-delim = 3apostrophe
+ml-literal-body = *mll-content *( mll-quotes 1*mll-content ) [ mll-quotes ]
 
-ml-literal-body = *( ml-literal-char / newline )
-ml-literal-char = %x09 / %x20-7E / non-ascii
+mll-content = mll-char / newline
+mll-char = %x09 / %x20-26 / %x28-7E / non-ascii
+mll-quotes = 1*2apostrophe
 
 ;; Integer
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -81,12 +81,13 @@ escape-seq-char =/ %x55 8HEXDIG ; UXXXXXXXX            U+XXXXXXXX
 ;; Multiline Basic String
 
 ml-basic-string = ml-basic-string-delim ml-basic-body ml-basic-string-delim
-
 ml-basic-string-delim = 3quotation-mark
+ml-basic-body = *mlb-content *( mlb-quotes 1*mlb-content ) [ mlb-quotes ]
 
-ml-basic-body = *( ml-basic-char / newline / ( escape ws newline ) )
-ml-basic-char = ml-basic-unescaped / escaped
-ml-basic-unescaped = wschar / %x21-5B / %x5D-7E / non-ascii
+mlb-content = mlb-char / newline / ( escape ws newline )
+mlb-char = mlb-unescaped / escaped
+mlb-quotes = 1*2quotation-mark
+mlb-unescaped = wschar / %x21 / %x23-5B / %x5D-7E / non-ascii
 
 ;; Literal String
 


### PR DESCRIPTION
This addresses the ambiguity in #640 in how quotation marks are parsed in multiline basic strings. It also addresses the same matter in multiline literal strings.