### PR TITLE
Clarify how dotted keys interact with ordinary table syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Clarify how dotted keys interact with ordinary table syntax.
 * Clarify in ABNF that UTF-16 surrogate code points (U+D800 - U+DFFF) are not
   allowed in strings or comments.
 * Allow raw tab characters in basic strings and multi-line basic strings.

--- a/README.md
+++ b/README.md
@@ -643,24 +643,29 @@ Empty tables are allowed and simply have no key/value pairs within them.
 
 Like keys, you cannot define any table more than once. Doing so is invalid.
 
-```
-# DO NOT DO THIS
-
+```toml
 [a]
 b = 1
 
-[a]
+[a] # This is invalid, it redefines a table.
 c = 2
+
+[a.b] # This would also be invalid, it redefines a key.
+d = 3
 ```
 
-```
-# DO NOT DO THIS EITHER
+This applies to dotted keys as well. Their super-tables may still be defined.
+Nothing is allowed to redefine previously declared dotted keys, however.
 
-[a]
-b = 1
+```toml
+a.b = 1
+a.c = 2
 
-[a.b]
-c = 2
+[a] # This is valid.
+d = 3
+c = 4 # This is invalid.
+
+[a] # A second definition of a table is still invalid.
 ```
 
 Inline Table


### PR DESCRIPTION
This is intended to close #631, or at least to hopefully further spur the discussion towards a final conclusion. It includes an example of how dotkey syntax allows some exceedingly flexible definitions of tables.