### PR TITLE
Immutable Inline tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Clarify that inline tables are immutable.
 * Clarify in ABNF that UTF-16 surrogate code points (U+D800 - U+DFFF) are not
   allowed in strings or comments.
 * Allow raw tab characters in basic strings and multi-line basic strings.

--- a/README.md
+++ b/README.md
@@ -701,6 +701,24 @@ type.name = "pug"
 
 ```
 
+Inline tables fully define the keys and sub-tables within them. New keys and
+sub-tables cannot be added to them.
+
+```toml
+[product]
+type = { name = "Nail" }
+# type.edible = false  # INVALID
+```
+
+Similarly, inline tables can not be used to add keys or sub-tables to an 
+already-defined table.
+
+```toml
+[product]
+type.name = "Nail"
+# type = { edible = false }  # INVALID
+```
+
 Array of Tables
 ---------------
 


### PR DESCRIPTION
Closes #630 
(maybe?) Supercedes and closes #647.

---

This was a draft I had locally that I just updated to use "cannot be added to them" borrowed from #647.