### PR TITLE
Clarify behavior of tables defined implicitly by dotted keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Clarify behavior of tables defined implicitly by dotted keys.
 * Clarify that inline tables are immutable.
 * Clarify in ABNF that UTF-16 surrogate code points (U+D800 - U+DFFF) are not
   allowed in strings or comments.

--- a/README.md
+++ b/README.md
@@ -706,6 +706,21 @@ Similarly, defining tables out-of-order is discouraged as well.
 [b]
 ```
 
+Dotted keys imply the creation of tables. Once created, the `[table]` form can
+only be used to define sub-tables within such tables.
+
+```toml
+[fruit]
+apple.color = "red"
+apple.taste.sweet = true
+
+# [fruit.apple]  # INVALID
+# [fruit.apple.taste]  # INVALID
+
+[fruit.apple.texture]  # you can add sub-tables
+smooth = true
+```
+
 Inline Table
 ------------
 

--- a/README.md
+++ b/README.md
@@ -706,8 +706,13 @@ Similarly, defining tables out-of-order is discouraged as well.
 [b]
 ```
 
-Dotted keys imply the creation of tables. Once created, the `[table]` form can
-only be used to define sub-tables within such tables.
+Dotted keys define everything to the left of each dot as a table. Since tables
+cannot be defined more than once, redefining such tables using a `[table]`
+header is not allowed. Likewise, using dotted keys to redefine tables already
+defined in `[table]` form is not allowed.
+
+The `[table]` form can, however, be used to define sub-tables within tables
+defined via dotted keys.
 
 ```toml
 [fruit]


### PR DESCRIPTION
Closes #631 
(maybe?) Supersedes and closes #654 