### PR TITLE
Permit leading zeroes in exponent parts of floats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Leading zeroes in exponent parts of floats are permitted.
 * Clarify that inline tables are immutable.
 * Clarify in ABNF that UTF-16 surrogate code points (U+D800 - U+DFFF) are not
   allowed in strings or comments.

--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ flt3 = -0.01
 
 # exponent
 flt4 = 5e+22
-flt5 = 1e6
+flt5 = 1e06
 flt6 = -2E-2
 
 # both
@@ -467,7 +467,8 @@ flt7 = 6.626e-34
 A fractional part is a decimal point followed by one or more digits.
 
 An exponent part is an E (upper or lower case) followed by an integer part
-(which follows the same rules as decimal integer values).
+(which follows the same rules as decimal integer values but may include leading
+zeros).
 
 Similar to integers, you may use underscores to enhance readability. Each
 underscore must be surrounded by at least one digit.
@@ -753,7 +754,7 @@ type = { name = "Nail" }
 # type.edible = false  # INVALID
 ```
 
-Similarly, inline tables can not be used to add keys or sub-tables to an 
+Similarly, inline tables can not be used to add keys or sub-tables to an
 already-defined table.
 
 ```toml

--- a/toml.abnf
+++ b/toml.abnf
@@ -137,7 +137,8 @@ frac = decimal-point zero-prefixable-int
 decimal-point = %x2E               ; .
 zero-prefixable-int = DIGIT *( DIGIT / underscore DIGIT )
 
-exp = "e" float-int-part
+exp = "e" float-exp-part
+float-exp-part = [ minus / plus ] zero-prefixable-int
 
 special-float = [ minus / plus ] ( inf / nan )
 inf = %x69.6e.66  ; inf


### PR DESCRIPTION
Per #356, this PR allows for leading zeroes on the integer parts of exponents in floats.