### PR TITLE
Cleanup sentence on out-of-order definitions of tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -691,7 +691,7 @@ b = 1
 c = 2
 ```
 
-Similarly, defining tables out-of-order is discouraged as well.
+Defining tables out-of-order is discouraged.
 
 ```toml
 # VALID BUT DISCOURAGED


### PR DESCRIPTION
"Similarly" and "as well" don't fit the local context. Closes #659.