### PR TITLE
Change ABNF array definition to permit single value types only

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ key = "value"
 ```
 
 Values must have one of the following types.
+
 - [String](#user-content-string)
 - [Integer](#user-content-integer)
 - [Float](#user-content-float)

--- a/README.md
+++ b/README.md
@@ -123,8 +123,19 @@ on the same line (though some values can be broken over multiple lines).
 key = "value"
 ```
 
-Values must be of the following types: String, Integer, Float, Boolean,
-Datetime, Array, or Inline Table. Unspecified values are invalid.
+Values must be one of the following types.
+- [String](#user-content-string)
+- [Integer](#user-content-integer)
+- [Float](#user-content-float)
+- [Boolean](#user-content-boolean)
+- [Offset Date-Time](#user-content-offset-date-time)
+- [Local Date-Time](#user-content-local-date-time)
+- [Local Date](#user-content-local-date)
+- [Local Time](#user-content-local-time)
+- [Array](#user-content-array)
+- [Inline Table](#user-content-inline-table)
+
+Unspecified values are invalid.
 
 ```toml
 key = # INVALID

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ on the same line (though some values can be broken over multiple lines).
 key = "value"
 ```
 
-Values must be one of the following types.
+Values must have one of the following types.
 - [String](#user-content-string)
 - [Integer](#user-content-integer)
 - [Float](#user-content-float)
@@ -590,9 +590,13 @@ Array
 -----
 
 Arrays are square brackets with values inside. Whitespace is ignored. Elements
-are separated by commas. Data types may not be mixed (different ways to define
-strings should be considered the same type, and so should arrays with different
-element types).
+are separated by commas.
+
+All values that are allowed in [key/value pairs](#user-content-keyvalue-pair)
+are also allowed in arrays, but all values within an array must have the same
+data type. Different ways to define strings are considered the same type, and so
+are arrays with different element types, and inline tables regardless of their
+contents.
 
 ```toml
 arr1 = [ 1, 2, 3 ]

--- a/toml.abnf
+++ b/toml.abnf
@@ -197,7 +197,10 @@ array-values =  array-strings
 array-values =/ array-booleans
 array-values =/ array-arrays
 array-values =/ array-inline-tables
-array-values =/ array-date-times
+array-values =/ array-offset-dts
+array-values =/ array-local-dts
+array-values =/ array-local-dates
+array-values =/ array-local-times
 array-values =/ array-floats
 array-values =/ array-integers
 
@@ -213,8 +216,17 @@ array-arrays =/ ws-comment-newline array ws [ array-sep ]
 array-inline-tables =  ws-comment-newline inline-table ws array-sep array-inline-tables
 array-inline-tables =/ ws-comment-newline inline-table ws [ array-sep ]
 
-array-date-times =  ws-comment-newline date-time ws array-sep array-date-times
-array-date-times =/ ws-comment-newline date-time ws [ array-sep ]
+array-offset-dts =  ws-comment-newline offset-date-time ws array-sep array-offset-dts
+array-offset-dts =/ ws-comment-newline offset-date-time ws [ array-sep ]
+
+array-local-dts =  ws-comment-newline local-date-time ws array-sep array-local-dts
+array-local-dts =/ ws-comment-newline local-date-time ws [ array-sep ]
+
+array-local-dates =  ws-comment-newline local-date ws array-sep array-local-dates
+array-local-dates =/ ws-comment-newline local-date ws [ array-sep ]
+
+array-local-times =  ws-comment-newline local-time ws array-sep array-local-times
+array-local-times =/ ws-comment-newline local-time ws [ array-sep ]
 
 array-floats =  ws-comment-newline float ws array-sep array-floats
 array-floats =/ ws-comment-newline float ws [ array-sep ]

--- a/toml.abnf
+++ b/toml.abnf
@@ -193,8 +193,34 @@ array = array-open [ array-values ] ws-comment-newline array-close
 array-open =  %x5B ; [
 array-close = %x5D ; ]
 
-array-values =  ws-comment-newline val ws array-sep array-values
-array-values =/ ws-comment-newline val ws [ array-sep ]
+array-values =  array-strings
+array-values =/ array-booleans
+array-values =/ array-arrays
+array-values =/ array-inline-tables
+array-values =/ array-date-times
+array-values =/ array-floats
+array-values =/ array-integers
+
+array-strings =  ws-comment-newline string ws array-sep array-strings
+array-strings =/ ws-comment-newline string ws [ array-sep ]
+
+array-booleans =  ws-comment-newline boolean ws array-sep array-booleans
+array-booleans =/ ws-comment-newline boolean ws [ array-sep ]
+
+array-arrays =  ws-comment-newline array ws array-sep array-arrays
+array-arrays =/ ws-comment-newline array ws [ array-sep ]
+
+array-inline-tables =  ws-comment-newline inline-table ws array-sep array-inline-tables
+array-inline-tables =/ ws-comment-newline inline-table ws [ array-sep ]
+
+array-date-times =  ws-comment-newline date-time ws array-sep array-date-times
+array-date-times =/ ws-comment-newline date-time ws [ array-sep ]
+
+array-floats =  ws-comment-newline float ws array-sep array-floats
+array-floats =/ ws-comment-newline float ws [ array-sep ]
+
+array-integers =  ws-comment-newline integer ws array-sep array-integers
+array-integers =/ ws-comment-newline integer ws [ array-sep ]
 
 array-sep = %x2C  ; , Comma
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -188,7 +188,7 @@ local-time = partial-time
 
 ;; Array
 
-array = array-open [ array-values ] ws-comment-newline array-close
+array = array-open ws-comment-newline [ array-values ] ws-comment-newline array-close
 
 array-open =  %x5B ; [
 array-close = %x5D ; ]
@@ -204,35 +204,35 @@ array-values =/ array-local-times
 array-values =/ array-floats
 array-values =/ array-integers
 
-array-strings =  ws-comment-newline string ws array-sep array-strings
-array-strings =/ ws-comment-newline string ws [ array-sep ]
+array-strings =  string ws array-sep ws-comment-newline array-strings
+array-strings =/ string ws [ array-sep ]
 
-array-booleans =  ws-comment-newline boolean ws array-sep array-booleans
-array-booleans =/ ws-comment-newline boolean ws [ array-sep ]
+array-booleans =  boolean ws array-sep ws-comment-newline array-booleans
+array-booleans =/ boolean ws [ array-sep ]
 
-array-arrays =  ws-comment-newline array ws array-sep array-arrays
-array-arrays =/ ws-comment-newline array ws [ array-sep ]
+array-arrays =  array ws array-sep ws-comment-newline array-arrays
+array-arrays =/ array ws [ array-sep ]
 
-array-inline-tables =  ws-comment-newline inline-table ws array-sep array-inline-tables
-array-inline-tables =/ ws-comment-newline inline-table ws [ array-sep ]
+array-inline-tables =  inline-table ws array-sep ws-comment-newline array-inline-tables
+array-inline-tables =/ inline-table ws [ array-sep ]
 
-array-offset-dts =  ws-comment-newline offset-date-time ws array-sep array-offset-dts
-array-offset-dts =/ ws-comment-newline offset-date-time ws [ array-sep ]
+array-offset-dts =  offset-date-time ws array-sep ws-comment-newline array-offset-dts
+array-offset-dts =/ offset-date-time ws [ array-sep ]
 
-array-local-dts =  ws-comment-newline local-date-time ws array-sep array-local-dts
-array-local-dts =/ ws-comment-newline local-date-time ws [ array-sep ]
+array-local-dts =  local-date-time ws array-sep ws-comment-newline array-local-dts
+array-local-dts =/ local-date-time ws [ array-sep ]
 
-array-local-dates =  ws-comment-newline local-date ws array-sep array-local-dates
-array-local-dates =/ ws-comment-newline local-date ws [ array-sep ]
+array-local-dates =  local-date ws array-sep ws-comment-newline array-local-dates
+array-local-dates =/ local-date ws [ array-sep ]
 
-array-local-times =  ws-comment-newline local-time ws array-sep array-local-times
-array-local-times =/ ws-comment-newline local-time ws [ array-sep ]
+array-local-times =  local-time ws array-sep ws-comment-newline array-local-times
+array-local-times =/ local-time ws [ array-sep ]
 
-array-floats =  ws-comment-newline float ws array-sep array-floats
-array-floats =/ ws-comment-newline float ws [ array-sep ]
+array-floats =  float ws array-sep ws-comment-newline array-floats
+array-floats =/ float ws [ array-sep ]
 
-array-integers =  ws-comment-newline integer ws array-sep array-integers
-array-integers =/ ws-comment-newline integer ws [ array-sep ]
+array-integers =  integer ws array-sep ws-comment-newline array-integers
+array-integers =/ integer ws [ array-sep ]
 
 array-sep = %x2C  ; , Comma
 


### PR DESCRIPTION
This modifies `toml.abnf` to enforce the current specification, which only considers homogeneous arrays to be valid. Per the `README`, strings are the same type regardless of their syntax, and arrays are the same type even if the values they contain differ in type between them. Empty arrays are still valid.