### PR TITLE
Explain ordering of subtables under arrays of tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,18 +819,17 @@ In JSON land, that would give you the following structure.
 
 You can create nested arrays of tables as well. Just use the same double bracket
 syntax on sub-tables. Each double-bracketed sub-table will belong to the most
-recently defined table element above it. Normal sub-tables (not arrays) likewise
-belong to the most recently defined table element above them.
+recently defined table element above it.
 
 ```toml
 [[fruit]]
   name = "apple"
 
-  [fruit.physical]  # subtable
+  [fruit.physical]
     color = "red"
     shape = "round"
 
-  [[fruit.variety]]  # nested array of tables
+  [[fruit.variety]]
     name = "red delicious"
 
   [[fruit.variety]]

--- a/README.md
+++ b/README.md
@@ -906,7 +906,7 @@ as an array must likewise produce a parse-time error.
   [[fruit.variety]]
     name = "red delicious"
 
-  # Not allowed: This table conflicts with the previous array of tables
+  # INVALID: This table conflicts with the previous array of tables
   [fruit.variety]
     name = "granny smith"
 
@@ -914,7 +914,7 @@ as an array must likewise produce a parse-time error.
     color = "red"
     shape = "round"
 
-  # Not allowed: This array of tables conflicts with the previous table
+  # INVALID: This array of tables conflicts with the previous table
   [[fruit.physical]]
     color = "green"
 ```


### PR DESCRIPTION
* Explicitly mention that table arrays can have regular subtables.
* Document that children of table arrays must not be defined above their parents (with example).
* Document that attempts to redefine a normal table as an array must produce a parse-time error (with example).

Closes #658.