### PR TITLE
Explicitly mention that arrays of tables can contain subtables

### DIFF
--- a/README.md
+++ b/README.md
@@ -819,17 +819,18 @@ In JSON land, that would give you the following structure.
 
 You can create nested arrays of tables as well. Just use the same double bracket
 syntax on sub-tables. Each double-bracketed sub-table will belong to the most
-recently defined table element above it.
+recently defined table element above it. Normal sub-tables (not arrays) likewise
+belong to the most recently defined table element above them.
 
 ```toml
 [[fruit]]
   name = "apple"
 
-  [fruit.physical]
+  [fruit.physical]  # subtable
     color = "red"
     shape = "round"
 
-  [[fruit.variety]]
+  [[fruit.variety]]  # nested array of tables
     name = "red delicious"
 
   [[fruit.variety]]


### PR DESCRIPTION
This is a spin-off of #664. It makes it explicit in the written spec that arrays of tables can contain regular (non-array) subtables which belong to the most recently defined table element above them.

@pradyunsg considered this unnecessary, arguing that "this is self-evident from the example JSON below". However, I would object that the examples should *not* introduce additional features, they should only *exemplify* what's already mentioned in the text.

Additionally, this particular example is currently a bit hard to understand since the text above it only talks about "double-bracketed sub-tables" (nested arrays of tables), making it surprising to also find a single-bracketed sub-table there (in fact, I initially overlooked it totally, instead just seeing what I had been told I would see).

This PR brings the text above the example in agreement with the example itself, following the "Explicit is better than implicit" principle.