### PR TITLE
Make the ABNF syntax tree, more semantic for ml-basic-string

### DIFF
--- a/toml.abnf
+++ b/toml.abnf
@@ -84,9 +84,10 @@ ml-basic-string = ml-basic-string-delim ml-basic-body ml-basic-string-delim
 
 ml-basic-string-delim = 3quotation-mark
 
-ml-basic-body = *( ml-basic-char / newline / ( escape ws newline ) )
+ml-basic-body = *( ml-basic-char / newline / ml-basic-escaped-nl )
 ml-basic-char = ml-basic-unescaped / escaped
 ml-basic-unescaped = wschar / %x21-5B / %x5D-7E / non-ascii
+ml-basic-escaped-nl = escape ws newline *( wschar / newline )
 
 ;; Literal String
 


### PR DESCRIPTION
this:
```
string = """ escaped \

     end"""
```

Was parsed as a single escaped newline, then as a newline part of the
string itself.

While it is fitting the role of rejecting invalid input and accepting
the valid one, it did not fit the role of parsing the content into
tokens.

To help the implementation, a multiline whitespace/newline token is
introduced: escaped-ws-nl

This fixes #669.