### PR TITLE
Deduplicate a rule in ABNF

### DIFF
--- a/toml.abnf
+++ b/toml.abnf
@@ -219,7 +219,7 @@ inline-table-open  = %x7B ws     ; {
 inline-table-close = ws %x7D     ; }
 inline-table-sep   = ws %x2C ws  ; , Comma
 
-inline-table-keyvals = key keyval-sep val [ inline-table-sep inline-table-keyvals ]
+inline-table-keyvals = keyval [ inline-table-sep inline-table-keyvals ]
 
 ;; Array Table
 


### PR DESCRIPTION
In hope that this will make reading the ABNF easier and the implementation simpler, the keyval can be deduplicated: it is in both plain root-level key-value and in inline-table's key-value, yet the content is exactly the same.