### PR TITLE
Clarify that control characters are not permitted in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Leading zeroes in exponent parts of floats are permitted.
+* Clarify that control characters are not permitted in comments.
 * Clarify behavior of tables defined implicitly by dotted keys.
 * Clarify that inline tables are immutable.
 * Clarify in ABNF that UTF-16 surrogate code points (U+D800 - U+DFFF) are not

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ key = "value"  # This is a comment at the end of a line
 another = "# This is not a comment"
 ```
 
+Control characters other than tab (U+0000 to U+0008, U+000A to U+001F, U+007F)
+are not permitted in comments.
+
 Key/Value Pair
 --------------
 


### PR DESCRIPTION
Fixes #567