### PR TITLE
fix some pretty small problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,8 +791,8 @@ same form as key/value pairs in standard tables. All value types are allowed,
 including inline tables.
 
 Inline tables are intended to appear on a single line. A terminating comma (also
-called trailing comma) is not permitted after the last key/value pair in an
-inline table.  No newlines are allowed between the curly braces unless they are
+called trailing comma) is not permitted after the last key/value pair in an
+inline table. No newlines are allowed between the curly braces unless they are
 valid within a value. Even so, it is strongly discouraged to break an inline
 table onto multiples lines. If you find yourself gripped with this desire, it
 means you should be using standard tables.
@@ -941,8 +941,8 @@ reverse that ordering must produce an error at parse time.
   name = "apple"
 ```
 
-Attempting to append to a statically defined array, even if that array is empty
-or of compatible type, must produce an error at parse time.
+Attempting to append to a statically defined array, even if that array is empty,
+must produce an error at parse time.
 
 ```
 # INVALID TOML DOC

--- a/README.md
+++ b/README.md
@@ -432,8 +432,8 @@ quot15 = '''Here are fifteen quotation marks: """""""""""""""'''
 # apos15 = '''Here are fifteen apostrophes: ''''''''''''''''''  # INVALID
 apos15 = "Here are fifteen apostrophes: '''''''''''''''"
 
-# 'That's still pointless', she said.
-str = ''''That's still pointless', she said.'''
+# 'That,' she said, 'is still pointless.'
+str = ''''That,' she said, 'is still pointless.''''
 ```
 
 Control characters other than tab are not permitted in a literal string. Thus,

--- a/versions/en/toml-v0.5.0.md
+++ b/versions/en/toml-v0.5.0.md
@@ -40,6 +40,7 @@ Table of contents
 - [Inline Table](#user-content-inline-table)
 - [Array of Tables](#user-content-array-of-tables)
 - [Filename Extension](#user-content-filename-extension)
+- [MIME Type](#user-content-mime-type)
 - [Comparison with Other Formats](#user-content-comparison-with-other-formats)
 - [Get Involved](#user-content-get-involved)
 - [Wiki](#user-content-wiki)


### PR DESCRIPTION
from #723 

1. https://github.com/toml-lang/toml/blame/master/README.md#L795 has two spaces after period.
2. https://github.com/toml-lang/toml/blame/master/README.md#L794 the space after key/value is \xA0, not \x20.
3. https://github.com/toml-lang/toml/blame/master/README.md#L945 or of compatible type should be removed, because now mixed type array is ok.

I found these when I was translating docs word by word. Since it's rc version now, fixing them do more good than harm.

---

for #725 

Make it clear in example, that multiline literal string can also end with (single) quote less than three, like multiline basic string do now.

---

#722
