### PR TITLE
Replace "expected" by more precise terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -488,8 +488,10 @@ oct2 = 0o755 # useful for Unix file permissions
 bin1 = 0b11010110
 ```
 
-64 bit (signed long) range expected (−9,223,372,036,854,775,808 to
-9,223,372,036,854,775,807).
+Arbitrary 64-bit signed integers (from −2^63 to 2^63−1) should be accepted and
+handled losslessly. If the result of parsing a value with unlimited precision
+would result in an integer that cannot be represented losslessly, an error must
+be thrown.
 
 Float
 -----
@@ -574,9 +576,9 @@ time with a space character (as permitted by RFC 3339 section 5.6).
 odt4 = 1979-05-27 07:32:00Z
 ```
 
-The precision of fractional seconds is implementation-specific, but at least
-millisecond precision is expected. If the value contains greater precision than
-the implementation can support, the additional precision must be truncated, not
+Millisecond precision is required. Further precision of fractional seconds is
+implementation-specific. If the value contains greater precision than the
+implementation can support, the additional precision must be truncated, not
 rounded.
 
 Local Date-Time
@@ -593,9 +595,9 @@ ldt1 = 1979-05-27T07:32:00
 ldt2 = 1979-05-27T00:32:00.999999
 ```
 
-The precision of fractional seconds is implementation-specific, but at least
-millisecond precision is expected. If the value contains greater precision than
-the implementation can support, the additional precision must be truncated, not
+Millisecond precision is required. Further precision of fractional seconds is
+implementation-specific. If the value contains greater precision than the
+implementation can support, the additional precision must be truncated, not
 rounded.
 
 Local Date
@@ -622,9 +624,9 @@ lt1 = 07:32:00
 lt2 = 00:32:00.999999
 ```
 
-The precision of fractional seconds is implementation-specific, but at least
-millisecond precision is expected. If the value contains greater precision than
-the implementation can support, the additional precision must be truncated, not
+Millisecond precision is required. Further precision of fractional seconds is
+implementation-specific. If the value contains greater precision than the
+implementation can support, the additional precision must be truncated, not
 rounded.
 
 Array

--- a/README.md
+++ b/README.md
@@ -489,9 +489,8 @@ bin1 = 0b11010110
 ```
 
 Arbitrary 64-bit signed integers (from −2^63 to 2^63−1) should be accepted and
-handled losslessly. If the result of parsing a value with unlimited precision
-would result in an integer that cannot be represented losslessly, an error must
-be thrown.
+handled losslessly. If an integer cannot be represented losslessly, an error
+must be thrown.
 
 Float
 -----


### PR DESCRIPTION
* Replace the vague term "expected" with the RFC 2119-compatible terms "should", "must", "required"
* Clarify that an error must be thrown if an integer cannot be represented losslessly

Fixes #736.