### PR TITLE
Allow comments w/ newlines before commas in arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-*  Clarify that comments with newlines are allowed before commas in arrays.
+*  Clarify that comments and newlines are allowed before commas in arrays.
 
 ## 1.0.0-rc.2 / 2020-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-Nothing.
+*  Clarify that comments with newlines are allowed before commas in arrays.
 
 ## 1.0.0-rc.2 / 2020-08-09
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -196,8 +196,8 @@ array = array-open [ array-values ] ws-comment-newline array-close
 array-open =  %x5B ; [
 array-close = %x5D ; ]
 
-array-values =  ws-comment-newline val ws array-sep array-values
-array-values =/ ws-comment-newline val ws [ array-sep ]
+array-values =  ws-comment-newline val ws-comment-newline array-sep array-values
+array-values =/ ws-comment-newline val ws-comment-newline [ array-sep ]
 
 array-sep = %x2C  ; , Comma
 

--- a/toml.md
+++ b/toml.md
@@ -614,8 +614,8 @@ contributors = [
 ```
 
 Arrays can span multiple lines. A terminating comma (also called trailing comma)
-is ok after the last value of the array. There can be an arbitrary number of
-newlines and comments before a value and before the closing bracket.
+is permitted after the last value of the array. Any number of newlines and
+comments may precede values, commas, and the closing bracket.
 
 ```toml
 integers2 = [


### PR DESCRIPTION
Per #766 this change updates the specification to allow comments with newlines before commas in arrays. Modifies toml.md, toml.abnf, and CHANGELOG.md.