### PR TITLE
Clarify indentation usage and remove indents from table examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * Clarify that indentation before keys is insignificant & discouraged.
 * Clarify that indentation before table headers is insignificant & discouraged.
-* Clarify that indentation inside arrays is treated as whitespace.
+* Clarify that indentation inside arrays is treated as whitespace and ignored.
 
 ## 1.0.0-rc.3 / 2020-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## unreleased
 
-* Clarify that indentation before keys is insignificant & discouraged.
-* Clarify that indentation before table headers is insignificant & discouraged.
-* Clarify that indentation inside arrays is treated as whitespace and ignored.
+* Clarify that indentation before keys is ignored.
+* Clarify that indentation before table headers is ignored.
+* Clarify that indentation between array values is ignored.
 
 ## 1.0.0-rc.3 / 2020-10-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## unreleased
 
-Nothing.
+* Clarify that indentation before keys is insignificant & discouraged.
+* Clarify that indentation before table headers is insignificant & discouraged.
+* Clarify that indentation inside arrays is treated as whitespace.
 
 ## 1.0.0-rc.3 / 2020-10-07
 

--- a/toml.md
+++ b/toml.md
@@ -172,12 +172,6 @@ fruit . flavor = "banana"   # same as fruit.flavor
 
 Indentation is treated as whitespace. Tabs and spaces before keys are ignored.
 
-```toml
-bad_fruit.name = "banana"
-  bad_fruit.color = "green"  # Indentation is VALID, BUT DISCOURAGED.
-bad_fruit.flavor = "blah"
-```
-
 Defining a key multiple times is invalid.
 
 ```
@@ -631,7 +625,7 @@ contributors = [
 Arrays can span multiple lines. A terminating comma (also called a trailing
 comma) is permitted after the last value of the array. Any number of newlines
 and comments may precede values, commas, and the closing bracket. Indentation
-between array values and commas is treated as whitespace, and is ignored.
+between array values and commas is treated as whitespace and ignored.
 
 ```toml
 integers2 = [
@@ -693,15 +687,6 @@ extraneous whitespace.
 ```
 
 Indentation is treated as whitespace. Tabs and spaces before keys are ignored.
-
-```toml
-[m]      # how to write subtables
-[m.n]    # use dotted keys to nest tables
-[m.n.o]  # best practice: write all headers flush-left
-
-[p]      # Indentation is VALID,
-  [p.q]    # BUT DISCOURAGED.
-```
 
 You don't need to specify all the super-tables if you don't want to. TOML knows
 how to do it for you.

--- a/toml.md
+++ b/toml.md
@@ -170,7 +170,7 @@ fruit. color = "yellow"    # same as fruit.color
 fruit . flavor = "banana"   # same as fruit.flavor
 ```
 
-Indentation is treated as whitespace. Tabs and spaces before keys are ignored.
+Indentation is treated as whitespace and ignored.
 
 Defining a key multiple times is invalid.
 

--- a/toml.md
+++ b/toml.md
@@ -171,7 +171,6 @@ fruit . flavor = "banana"   # same as fruit.flavor
 ```
 
 Indentation is treated as whitespace. Tabs and spaces before keys are ignored.
-You shouldn't use them. But if you must, use them sparingly.
 
 ```toml
 bad_fruit.name = "banana"
@@ -694,7 +693,6 @@ extraneous whitespace.
 ```
 
 Indentation is treated as whitespace. Tabs and spaces before keys are ignored.
-You shouldn't use them. But if you must, use them sparingly.
 
 ```toml
 [m]      # how to write subtables

--- a/toml.md
+++ b/toml.md
@@ -686,7 +686,7 @@ extraneous whitespace.
 [ j . "ʞ" . 'l' ]  # same as [j."ʞ".'l']
 ```
 
-Indentation is treated as whitespace. Tabs and spaces before keys are ignored.
+Indentation is treated as whitespace and ignored.
 
 You don't need to specify all the super-tables if you don't want to. TOML knows
 how to do it for you.

--- a/toml.md
+++ b/toml.md
@@ -631,8 +631,8 @@ contributors = [
 
 Arrays can span multiple lines. A terminating comma (also called a trailing
 comma) is permitted after the last value of the array. Any number of newlines
-and comments may precede values, commas, and the closing bracket. Indentation is
-treated as whitespace.
+and comments may precede values, commas, and the closing bracket. Indentation
+between array values and commas is treated as whitespace, and is ignored.
 
 ```toml
 integers2 = [

--- a/toml.md
+++ b/toml.md
@@ -161,8 +161,23 @@ In JSON land, that would give you the following structure:
 }
 ```
 
-Whitespace around dot-separated parts is ignored, however, best practice is to
+Whitespace around dot-separated parts is ignored. However, best practice is to
 not use any extraneous whitespace.
+
+```toml
+fruit.name = "banana"     # this is best practice
+fruit. color = "yellow"    # same as fruit.color
+fruit . flavor = "banana"   # same as fruit.flavor
+```
+
+Indentation is treated as whitespace. Tabs and spaces before keys are ignored.
+You shouldn't use them. But if you must, use them sparingly.
+
+```toml
+bad_fruit.name = "banana"
+  bad_fruit.color = "green"  # Indentation is VALID, BUT DISCOURAGED.
+bad_fruit.flavor = "blah"
+```
 
 Defining a key multiple times is invalid.
 
@@ -614,9 +629,10 @@ contributors = [
 ]
 ```
 
-Arrays can span multiple lines. A terminating comma (also called trailing comma)
-is permitted after the last value of the array. Any number of newlines and
-comments may precede values, commas, and the closing bracket.
+Arrays can span multiple lines. A terminating comma (also called a trailing
+comma) is permitted after the last value of the array. Any number of newlines
+and comments may precede values, commas, and the closing bracket. Indentation is
+treated as whitespace.
 
 ```toml
 integers2 = [
@@ -667,7 +683,7 @@ In JSON land, that would give you the following structure:
 { "dog": { "tater.man": { "type": { "name": "pug" } } } }
 ```
 
-Whitespace around the key is ignored, however, best practice is to not use any
+Whitespace around the key is ignored. However, best practice is to not use any
 extraneous whitespace.
 
 ```toml
@@ -675,6 +691,18 @@ extraneous whitespace.
 [ d.e.f ]          # same as [d.e.f]
 [ g .  h  . i ]    # same as [g.h.i]
 [ j . "ʞ" . 'l' ]  # same as [j."ʞ".'l']
+```
+
+Indentation is treated as whitespace. Tabs and spaces before keys are ignored.
+You shouldn't use them. But if you must, use them sparingly.
+
+```toml
+[m]      # how to write subtables
+[m.n]    # use dotted keys to nest tables
+[m.n.o]  # best practice: write all headers flush-left
+
+[p]      # Indentation is VALID,
+  [p.q]    # BUT DISCOURAGED.
 ```
 
 You don't need to specify all the super-tables if you don't want to. TOML knows
@@ -850,23 +878,23 @@ element.
 
 ```toml
 [[fruit]]
-  name = "apple"
+name = "apple"
 
-  [fruit.physical]  # subtable
-    color = "red"
-    shape = "round"
+[fruit.physical]  # subtable
+color = "red"
+shape = "round"
 
-  [[fruit.variety]]  # nested array of tables
-    name = "red delicious"
+[[fruit.variety]]  # nested array of tables
+name = "red delicious"
 
-  [[fruit.variety]]
-    name = "granny smith"
+[[fruit.variety]]
+name = "granny smith"
 
 [[fruit]]
-  name = "banana"
+name = "banana"
 
-  [[fruit.variety]]
-    name = "plantain"
+[[fruit.variety]]
+name = "plantain"
 ```
 
 The above TOML maps to the following JSON.
@@ -902,12 +930,12 @@ reverse that ordering must produce an error at parse time.
 ```
 # INVALID TOML DOC
 [fruit.physical]  # subtable, but to which parent element should it belong?
-  color = "red"
-  shape = "round"
+color = "red"
+shape = "round"
 
 [[fruit]]  # parser must throw an error upon discovering that "fruit" is
            # an array rather than a table
-  name = "apple"
+name = "apple"
 ```
 
 Attempting to append to a statically defined array, even if that array is empty,
@@ -927,22 +955,22 @@ as an array must likewise produce a parse-time error.
 ```
 # INVALID TOML DOC
 [[fruit]]
-  name = "apple"
+name = "apple"
 
-  [[fruit.variety]]
-    name = "red delicious"
+[[fruit.variety]]
+name = "red delicious"
 
-  # INVALID: This table conflicts with the previous array of tables
-  [fruit.variety]
-    name = "granny smith"
+# INVALID: This table conflicts with the previous array of tables
+[fruit.variety]
+name = "granny smith"
 
-  [fruit.physical]
-    color = "red"
-    shape = "round"
+[fruit.physical]
+color = "red"
+shape = "round"
 
-  # INVALID: This array of tables conflicts with the previous table
-  [[fruit.physical]]
-    color = "green"
+# INVALID: This array of tables conflicts with the previous table
+[[fruit.physical]]
+color = "green"
 ```
 
 You may also use inline tables where appropriate:


### PR DESCRIPTION
During discussion [in issue 744](https://github.com/toml-lang/toml/issues/744#issuecomment-706912461) and elsewhere, users coming from Python with no experience with INI file formats were confused by the presence of indentation in a few of the examples in `toml.md`. Indentation is essentially whitespace (except inside strings) and is discouraged before keys and table headers, but this wasn't being stated clearly.

This PR makes these facts clear about indentation. For keys and table headers in examples, all indentation was stripped, and indentation is clearly treated as whitespace and its use is discouraged. For consistency, similar language was applied to array values, though indentation was preserved and it isn't discouraged there. A few minor grammar corrections were also made.