### PR TITLE
Clarify and describe the top-level table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+* Clarify and describe the top-level table.
 * Clarify that indentation before keys is ignored.
 * Clarify that indentation before table headers is ignored.
 * Clarify that indentation between array values is ignored.

--- a/toml.md
+++ b/toml.md
@@ -686,21 +686,6 @@ extraneous whitespace.
 [ j . "ʞ" . 'l' ]  # same as [j."ʞ".'l']
 ```
 
-The top-level table, also called the root table, starts at the beginning of the
-document and ends just before the first table header (or EOF). Unlike other
-tables, it is nameless and cannot be relocated.
-
-```toml
-# Top-level table begins.
-name = "Fido"
-breed = "pug"
-
-# Top-level table ends.
-[owner]
-name = "Regina Dogman"
-member_since = 1999-08-04
-```
-
 Indentation is treated as whitespace and ignored.
 
 You don't need to specify all the super-tables if you don't want to. TOML knows
@@ -753,6 +738,21 @@ Defining tables out-of-order is discouraged.
 [fruit.apple]
 [fruit.orange]
 [animal]
+```
+
+The top-level table, also called the root table, starts at the beginning of the
+document and ends just before the first table header (or EOF). Unlike other
+tables, it is nameless and cannot be relocated.
+
+```toml
+# Top-level table begins.
+name = "Fido"
+breed = "pug"
+
+# Top-level table ends.
+[owner]
+name = "Regina Dogman"
+member_since = 1999-08-04
 ```
 
 Dotted keys define everything to the left of each dot as a table. Since tables

--- a/toml.md
+++ b/toml.md
@@ -686,6 +686,21 @@ extraneous whitespace.
 [ j . "ʞ" . 'l' ]  # same as [j."ʞ".'l']
 ```
 
+The top-level table, also called the root table, starts at the beginning of the
+document and ends just before the first table header (or EOF). Unlike other
+tables, it is nameless and cannot be relocated.
+
+```toml
+# Top-level table begins.
+name = "Fido"
+breed = "pug"
+
+# Top-level table ends.
+[owner]
+name = "Regina Dogman"
+member_since = 1999-08-04
+```
+
 Indentation is treated as whitespace and ignored.
 
 You don't need to specify all the super-tables if you don't want to. TOML knows


### PR DESCRIPTION
This PR contains a paragraph and new example in the Table section of `toml.md` that explicitly describes the top-level table. The text and the example makes it clear that this table is nameless and cannot be relocated.