### PR TITLE
Add shorthand for escape character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Clarify that indentation before keys is ignored.
 * Clarify that indentation before table headers is ignored.
 * Clarify that indentation between array values is ignored.
+* Add new `\e` shorthand for the escape character.
 
 ## 1.0.0-rc.3 / 2020-10-07
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -74,6 +74,7 @@ escape = %x5C                   ; \
 escape-seq-char =  %x22         ; "    quotation mark  U+0022
 escape-seq-char =/ %x5C         ; \    reverse solidus U+005C
 escape-seq-char =/ %x62         ; b    backspace       U+0008
+escape-seq-char =/ %x65         ; e    escape          U+001B
 escape-seq-char =/ %x66         ; f    form feed       U+000C
 escape-seq-char =/ %x6E         ; n    line feed       U+000A
 escape-seq-char =/ %x72         ; r    carriage return U+000D

--- a/toml.md
+++ b/toml.md
@@ -274,6 +274,7 @@ For convenience, some popular characters have a compact escape sequence.
 \n         - linefeed        (U+000A)
 \f         - form feed       (U+000C)
 \r         - carriage return (U+000D)
+\e         - escape          (U+001B)
 \"         - quote           (U+0022)
 \\         - backslash       (U+005C)
 \uXXXX     - unicode         (U+XXXX)


### PR DESCRIPTION
This adds a shorthand for the escape character `\e` (0x1B).

This is useful especially when talking about things like terminal escape
sequences, which use this character regularly.

Fixes #715.