### PR TITLE
ABNF: Reflect first newline in multiline string explicitly

### DIFF
--- a/toml.abnf
+++ b/toml.abnf
@@ -83,7 +83,8 @@ escape-seq-char =/ %x55 8HEXDIG ; UXXXXXXXX            U+XXXXXXXX
 
 ;; Multiline Basic String
 
-ml-basic-string = ml-basic-string-delim ml-basic-body ml-basic-string-delim
+ml-basic-string = ml-basic-string-delim [ newline ] ml-basic-body
+                  ml-basic-string-delim
 ml-basic-string-delim = 3quotation-mark
 ml-basic-body = *mlb-content *( mlb-quotes 1*mlb-content ) [ mlb-quotes ]
 
@@ -103,7 +104,8 @@ literal-char = %x09 / %x20-26 / %x28-7E / non-ascii
 
 ;; Multiline Literal String
 
-ml-literal-string = ml-literal-string-delim ml-literal-body ml-literal-string-delim
+ml-literal-string = ml-literal-string-delim [ newline ] ml-literal-body
+                    ml-literal-string-delim
 ml-literal-string-delim = 3apostrophe
 ml-literal-body = *mll-content *( mll-quotes 1*mll-content ) [ mll-quotes ]
 


### PR DESCRIPTION
The spec states that, for both multiline basic and literal strings:

> A newline immediately following the opening delimiter will be trimmed.

This is currently not reflected in the ABNF definition, using basic
string as an example:

```abnf
ml-basic-string = ml-basic-string-delim ml-basic-body ml-basic-string-delim
ml-basic-string-delim = 3quotation-mark
ml-basic-body = *mlb-content *( mlb-quotes 1*mlb-content ) [ mlb-quotes ]
```

Implemented directly (or via an ABNF parser generator), the initial new line 
sequence after `"""` will be part of `ml-basic-body`. This is misleading.

IMHO, this special newline should have its own place in the ABNF syntax.
Hence this patch.