### PR TITLE
Clarify sub-millisecond precision is allowed

### DIFF
--- a/toml.md
+++ b/toml.md
@@ -563,7 +563,8 @@ To unambiguously represent a specific instant in time, you may use an
 ```toml
 odt1 = 1979-05-27T07:32:00Z
 odt2 = 1979-05-27T00:32:00-07:00
-odt3 = 1979-05-27T00:32:00.999999-07:00
+odt3 = 1979-05-27T00:32:00.5-07:00
+odt4 = 1979-05-27T00:32:00.999999-07:00
 ```
 
 For the sake of readability, you may replace the T delimiter between date and
@@ -581,10 +582,9 @@ odt5 = 1979-05-27 07:32Z
 odt6 = 1979-05-27 07:32-07:00
 ```
 
-Millisecond precision is required. Further precision of fractional seconds is
-implementation-specific. If the value contains greater precision than the
-implementation can support, the additional precision must be truncated, not
-rounded.
+Implementations are required to support at least millisecond precision.
+Additional digits of precision may be specified, but if they exceed the
+supported precision then the extra digits must be truncated, not rounded.
 
 ## Local Date-Time
 
@@ -596,7 +596,8 @@ implementation-specific.
 
 ```toml
 ldt1 = 1979-05-27T07:32:00
-ldt2 = 1979-05-27T00:32:00.999999
+ldt2 = 1979-05-27T07:32:00.5
+ldt3 = 1979-05-27T00:32:00.999999
 ```
 
 Seconds may be omitted, in which case `:00` will be assumed.
@@ -609,6 +610,10 @@ Millisecond precision is required. Further precision of fractional seconds is
 implementation-specific. If the value contains greater precision than the
 implementation can support, the additional precision must be truncated, not
 rounded.
+
+Implementations are required to support at least millisecond precision.
+Additional digits of precision may be specified, but if they exceed the
+supported precision then the extra digits must be truncated, not rounded.
 
 ## Local Date
 
@@ -629,7 +634,8 @@ or timezone.
 
 ```toml
 lt1 = 07:32:00
-lt2 = 00:32:00.999999
+lt2 = 00:32:00.5
+lt3 = 00:32:00.999999
 ```
 
 Seconds may be omitted, in which case `:00` will be assumed.
@@ -642,6 +648,10 @@ Millisecond precision is required. Further precision of fractional seconds is
 implementation-specific. If the value contains greater precision than the
 implementation can support, the additional precision must be truncated, not
 rounded.
+
+Implementations are required to support at least millisecond precision.
+Additional digits of precision may be specified, but if they exceed the
+supported precision then the extra digits must be truncated, not rounded.
 
 ## Array
 


### PR DESCRIPTION
"Millisecond precision is required" could be interpreted as a requirement for input to be valid TOML. This commit adds examples of valid TOML time values that uses tens of second to remove the ambiguity.

Refs: https://github.com/alexcrichton/toml-rs/pull/416
Co-Authored-By: Dave Ostroske <eksortso@users.noreply.github.com>