### PR TITLE
Update ports in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ dob = 1979-05-27T07:32:00-08:00 # First class dates
 
 [database]
 server = "192.168.1.1"
-ports = [ 8001, 8001, 8002 ]
+ports = [ 8000, 8001, 8002 ]
 connection_max = 5000
 enabled = true
 


### PR DESCRIPTION
It doesn't make sense to have the same port `8001` appear twice in the array. I've updated the README with the `ports` array to be `[ 8000, 8001, 8002 ]`, presumably as it was originally intended.

For more on this topic, please see the conversation in https://github.com/toml-lang/toml.io/pull/37.