### PR TITLE
Allow 0X, 0O, and 0B literals as capitals

### DIFF
--- a/toml.abnf
+++ b/toml.abnf
@@ -124,9 +124,9 @@ digit1-9 = %x31-39                 ; 1-9
 digit0-7 = %x30-37                 ; 0-7
 digit0-1 = %x30-31                 ; 0-1
 
-hex-prefix = %x30.78               ; 0x
-oct-prefix = %x30.6F               ; 0o
-bin-prefix = %x30.62               ; 0b
+hex-prefix = %x30."x"              ; 0x, 0X
+oct-prefix = %x30."o"              ; 0o, 0O
+bin-prefix = %x30."b"              ; 0b, 0B
 
 dec-int = [ minus / plus ] unsigned-dec-int
 unsigned-dec-int = DIGIT / digit1-9 1*( DIGIT / underscore DIGIT )


### PR DESCRIPTION
Currently only "0x42" is accepted as a valid hex literal; "0X42" is
invalid.

I'm not sure if there's a good reason to not accept capital letters?
This is something that already works in many programming languages (not
all though, for example Go doesn't) and I don't see any downsides. I
can't find any previous discussions on this.

This also matches with the datetime parsing where "t" and "z" are
explicitly accepted as well (i.e. "1970-01-01t00:00:00z").

Since ABNF is case-insensitive we can use the "x" string for this
instead of specifying the codepoints, which is also a wee bit clearer.