### PR TITLE
Clarify that multi-line strings are not allowed in key names

### DIFF
--- a/toml.md
+++ b/toml.md
@@ -128,12 +128,13 @@ to use bare keys except when absolutely necessary.
 ```
 
 A bare key must be non-empty, but an empty quoted key is allowed (though
-discouraged).
+discouraged). You cannot use multi-line strings to define quoted keys.
 
 ```toml
-= "no key name"  # INVALID
-"" = "blank"     # VALID but discouraged
-'' = 'blank'     # VALID but discouraged
+= "no key name"           # INVALID
+"""key""" = "not allowed" # INVALID
+"" = "blank"              # VALID but discouraged
+'' = 'blank'              # VALID but discouraged
 ```
 
 **Dotted keys** are a sequence of bare or quoted keys joined with a dot. This


### PR DESCRIPTION
There have been two cases recently where I had someone who was confused
about this.

This clarifies that multi-line strings are not allowed as key names for
the casual reader; the phrases "basic string" and "literal string" have
a specific meaning in the TOML spec, but that's not really obvious if
you're just looking up "what is the valid syntax for a key?" as the
rules are explained in a different section, and it requires some careful
reading.