### PR TITLE
Clarify where and how dotted keys define tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-Nothing.
+* Clarify where and how dotted keys define tables.
 
 ## 1.0.0 / 2021-01-11
 

--- a/toml.md
+++ b/toml.md
@@ -759,8 +759,9 @@ name = "Regina Dogman"
 member_since = 1999-08-04
 ```
 
-Dotted keys create and define a table for each key part before the last one,
-provided that such tables were not previously created.
+Dotted keys create and define a table for each key part before the last one. Any
+such table must have all its key/value pairs defined under the current `[table]`
+header, or in the root table if defined before all headers.
 
 ```toml
 fruit.apple.color = "red"

--- a/toml.md
+++ b/toml.md
@@ -762,7 +762,7 @@ member_since = 1999-08-04
 
 Dotted keys create and define a table for each key part before the last one. Any
 such table must have all its key/value pairs defined under the current `[table]`
-header, or in the root table if defined before all headers.
+header, or in the root table if defined before all headers, or in one inline table.
 
 ```toml
 fruit.apple.color = "red"


### PR DESCRIPTION
Removes and replaces language that could potentially allow dotted keys in a parent table of an existing table to inject key/value pairs into subtables of the existing table. Closes #846.

This PR replaces the previous PR #848.