### PR TITLE
Force CRLF line endings in toml.abnf

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+toml.abnf text eol=crlf

--- a/toml.abnf
+++ b/toml.abnf
@@ -1,6 +1,10 @@
 ;; This document describes TOML's syntax, using the ABNF format (defined in
 ;; RFC 5234 -- https://www.ietf.org/rfc/rfc5234.txt).
 ;;
+;; Although a TOML document must be valid UTF-8, this grammar is written to
+;; apply to the string of non-negative integers that are the Unicode Scalar
+;; Values obtained from decoding the UTF-8 input.
+;;
 ;; All valid TOML documents will match this description, however certain
 ;; invalid documents would need to be rejected as per the semantics described
 ;; in the supporting text description.

--- a/toml.abnf
+++ b/toml.abnf
@@ -1,9 +1,8 @@
 ;; This document describes TOML's syntax, using the ABNF format (defined in
 ;; RFC 5234 -- https://www.ietf.org/rfc/rfc5234.txt).
 ;;
-;; Although a TOML document must be valid UTF-8, this grammar is written to
-;; apply to the string of non-negative integers that are the Unicode Scalar
-;; Values obtained from decoding the UTF-8 input.
+;; Although a TOML document must be valid UTF-8, this grammar refers to the
+;; Unicode Code Points you get after you decode the UTF-8 input.
 ;;
 ;; All valid TOML documents will match this description, however certain
 ;; invalid documents would need to be rejected as per the semantics described


### PR DESCRIPTION
…  add .gitattributes so CRLF is added at checkout.  
Fixes issue #873 .  

Although the diff looks like the only change is the one added comment paragraph about UTF-8,  
the .gitattributes will convert the LFs to CRLFs.
