### PR TITLE
Clarify trailing commas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Clarify where and how dotted keys define tables.
+* Clarify that a trailing comma is not required on the last item in an array.
 
 ## 1.0.0 / 2021-01-11
 

--- a/toml.md
+++ b/toml.md
@@ -628,9 +628,10 @@ contributors = [
 ```
 
 Arrays can span multiple lines. A terminating comma (also called a trailing
-comma) is permitted after the last value of the array. Any number of newlines
-and comments may precede values, commas, and the closing bracket. Indentation
-between array values and commas is treated as whitespace and ignored.
+comma) is permitted, but not required, after the last value of the array.
+Any number of newlines and comments may precede values, commas, and the closing
+bracket. Indentation between array values and commas is treated as whitespace and
+ignored.
 
 ```toml
 integers2 = [


### PR DESCRIPTION
I was trying to find out whether a comma is required behind the last item in array.

The Documentation currently states the following:

> A terminating comma (also called a trailing comma) is permitted after the last value of the array.

This, however, may arouse the suspicion that the comma is, in fact, required or encouraged. This PR changes the wording of that paragraph to make it abundantly clear that both options, with or without comma, are possible and equally valid.