### PR TITLE
Fix `\e` CHANGELOG note being in the wrong place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## unreleased
 
 * Clarify where and how dotted keys define tables.
+* Add new `\e` shorthand for the escape character.
 
 ## 1.0.0 / 2021-01-11
 
@@ -11,7 +12,6 @@
 * Clarify that indentation before keys is ignored.
 * Clarify that indentation before table headers is ignored.
 * Clarify that indentation between array values is ignored.
-* Add new `\e` shorthand for the escape character.
 
 ## 1.0.0-rc.3 / 2020-10-07
 


### PR DESCRIPTION
The `\e` PR, #790, was made before v1.0.0 was released, so the change it makes to CHANGELOG put the change note in the wrong place.