### PR TITLE
Replace "UTF-8 characters" with "Unicode characters"

### DIFF
--- a/toml.md
+++ b/toml.md
@@ -260,7 +260,6 @@ String
 
 There are four ways to express strings: basic, multi-line basic, literal, and
 multi-line literal. All strings must contain only valid Unicode characters.
-Strings should be implemented as UTF-8 byte sequences.
 
 **Basic strings** are surrounded by quotation marks (`"`). Any Unicode character
 may be used except those that must be escaped: quotation mark, backslash, and

--- a/toml.md
+++ b/toml.md
@@ -259,7 +259,8 @@ String
 ------
 
 There are four ways to express strings: basic, multi-line basic, literal, and
-multi-line literal. All strings must contain only valid UTF-8 characters.
+multi-line literal. All strings must contain only valid Unicode characters.
+Strings should be implemented as UTF-8 byte sequences.
 
 **Basic strings** are surrounded by quotation marks (`"`). Any Unicode character
 may be used except those that must be escaped: quotation mark, backslash, and


### PR DESCRIPTION
UTF-8 is an encoding, not a character set, so "UTF-8 character" is not correct.

I picked the "should be implemented as" wording from floats, but am not sure this is what you want. It feels like there should be some consistent way to say "TOML interpreters should output $type as $format" for strings, integers, and floats (and maybe others...).