### PR TITLE
Make seconds optional in Date-Time and Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Clarify where and how dotted keys define tables.
 * Add new `\e` shorthand for the escape character.
+* Seconds in Date-Time and Time values are now optional.
 
 ## 1.0.0 / 2021-01-11
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -175,7 +175,7 @@ time-secfrac   = "." 1*DIGIT
 time-numoffset = ( "+" / "-" ) time-hour ":" time-minute
 time-offset    = "Z" / time-numoffset
 
-partial-time   = time-hour ":" time-minute ":" time-second [ time-secfrac ]
+partial-time   = time-hour ":" time-minute [ ":" time-second [ time-secfrac ] ]
 full-date      = date-fullyear "-" date-month "-" date-mday
 full-time      = partial-time time-offset
 

--- a/toml.md
+++ b/toml.md
@@ -553,6 +553,15 @@ time with a space character (as permitted by RFC 3339 section 5.6).
 odt4 = 1979-05-27 07:32:00Z
 ```
 
+One exception to RFC 3339 is permitted: seconds may be omitted if the instant
+occurs at a zero-second mark. In such a case, the offset immediately follows
+the minutes.
+
+```toml
+odt5 = 1979-05-27 07:32Z
+odt6 = 1979-05-27 07:32-07:00
+```
+
 Millisecond precision is required. Further precision of fractional seconds is
 implementation-specific. If the value contains greater precision than the
 implementation can support, the additional precision must be truncated, not
@@ -570,6 +579,13 @@ implementation-specific.
 ```toml
 ldt1 = 1979-05-27T07:32:00
 ldt2 = 1979-05-27T00:32:00.999999
+```
+
+Seconds may be omitted if the local instant is at a zero-second mark. In such a
+case, the colon and digits following the minutes are removed.
+
+```toml
+ldt3 = 1979-05-27T07:32
 ```
 
 Millisecond precision is required. Further precision of fractional seconds is
@@ -599,6 +615,13 @@ or timezone.
 ```toml
 lt1 = 07:32:00
 lt2 = 00:32:00.999999
+```
+
+Seconds may be omitted if the local time is at a zero-second mark. In such a
+case, the colon and digits following the minutes are removed.
+
+```toml
+lt3 = 07:32
 ```
 
 Millisecond precision is required. Further precision of fractional seconds is

--- a/toml.md
+++ b/toml.md
@@ -553,9 +553,8 @@ time with a space character (as permitted by RFC 3339 section 5.6).
 odt4 = 1979-05-27 07:32:00Z
 ```
 
-One exception to RFC 3339 is permitted: seconds may be omitted if the instant
-occurs at a zero-second mark. In such a case, the offset immediately follows
-the minutes.
+One exception to RFC 3339 is permitted: seconds may be omitted, in which case
+`:00` will be assumed. The offset immediately follows the minutes.
 
 ```toml
 odt5 = 1979-05-27 07:32Z
@@ -581,8 +580,7 @@ ldt1 = 1979-05-27T07:32:00
 ldt2 = 1979-05-27T00:32:00.999999
 ```
 
-Seconds may be omitted if the local instant is at a zero-second mark. In such a
-case, the colon and digits following the minutes are removed.
+Seconds may be omitted, in which case `:00` will be assumed.
 
 ```toml
 ldt3 = 1979-05-27T07:32
@@ -617,8 +615,7 @@ lt1 = 07:32:00
 lt2 = 00:32:00.999999
 ```
 
-Seconds may be omitted if the local time is at a zero-second mark. In such a
-case, the colon and digits following the minutes are removed.
+Seconds may be omitted, in which case `:00` will be assumed.
 
 ```toml
 lt3 = 07:32


### PR DESCRIPTION
Allows the seconds portion of values with Offset Date-Time, Local Date-Time, and Local Time type to be omitted. Closes #671.

This PR replaces the older PR #696, which was written pre-v1.0.0. The exact same changes to the text in the specification and the ABNF appear in both PR's.