### PR TITLE
Permit more control characters in comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## unreleased
 
-- Relax comment parsing; control characters are again permitted.
+- Relax comment parsing; most control characters are again permitted.
 - Allow newline after key/values in inline tables.
 - Allow trailing comma in inline tables.
 - Clarify where and how dotted keys define tables.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Relax comment parsing; control characters are again permitted.
 - Allow newline after key/values in inline tables.
 - Allow trailing comma in inline tables.
 - Clarify where and how dotted keys define tables.

--- a/toml.abnf
+++ b/toml.abnf
@@ -83,8 +83,8 @@ quotation-mark = %x22            ; "
 
 basic-char = basic-unescaped / escaped
 basic-unescaped = wschar / %x21 / %x23-5B / %x5D-7E / non-ascii
-
 escaped = escape escape-seq-char
+
 escape = %x5C                   ; \
 escape-seq-char =  %x22         ; "    quotation mark  U+0022
 escape-seq-char =/ %x5C         ; \    reverse solidus U+005C

--- a/toml.abnf
+++ b/toml.abnf
@@ -39,7 +39,8 @@ newline =/ %x0D.0A  ; CRLF
 
 comment = comment-start-symbol *allowed-comment-char
 comment-start-symbol = %x23 ; #
-allowed-comment-char = %x01-%09 / %0E-10FFFF
+allowed-comment-char = %x01-09 / %x0E-7F / non-ascii
+non-ascii = %x80-D7FF / %xE000-10FFFF
 
 ;; Key-Value pairs
 
@@ -82,7 +83,6 @@ quotation-mark = %x22            ; "
 
 basic-char = basic-unescaped / escaped
 basic-unescaped = wschar / %x21 / %x23-5B / %x5D-7E / non-ascii
-non-ascii = %x80-D7FF / %xE000-10FFFF
 
 escaped = escape escape-seq-char
 escape = %x5C                   ; \

--- a/toml.abnf
+++ b/toml.abnf
@@ -39,7 +39,7 @@ newline =/ %x0D.0A  ; CRLF
 
 comment-start-symbol = %x23 ; #
 non-ascii = %x80-D7FF / %xE000-10FFFF
-non-linefeed = %x00-09 / %x0B-7F / non-ascii
+non-linefeed = %x00-09 / %x0B-0C / %x0E-7F / non-ascii
 
 comment = comment-start-symbol *non-linefeed
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -39,9 +39,9 @@ newline =/ %x0D.0A  ; CRLF
 
 comment-start-symbol = %x23 ; #
 non-ascii = %x80-D7FF / %xE000-10FFFF
-non-eol = %x00-09 / %x0B-7F / non-ascii
+non-linefeed = %x00-09 / %x0B-7F / non-ascii
 
-comment = comment-start-symbol *non-eol
+comment = comment-start-symbol *non-linefeed
 
 ;; Key-Value pairs
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -39,7 +39,7 @@ newline =/ %x0D.0A  ; CRLF
 
 comment-start-symbol = %x23 ; #
 non-ascii = %x80-D7FF / %xE000-10FFFF
-non-eol = %x09 / %x20-7E / non-ascii
+non-eol = %x00-09 / %x0B-7F / non-ascii
 
 comment = comment-start-symbol *non-eol
 

--- a/toml.abnf
+++ b/toml.abnf
@@ -37,11 +37,9 @@ newline =/ %x0D.0A  ; CRLF
 
 ;; Comment
 
+comment = comment-start-symbol *allowed-comment-char
 comment-start-symbol = %x23 ; #
-non-ascii = %x80-D7FF / %xE000-10FFFF
-non-linefeed = %x00-09 / %x0B-0C / %x0E-7F / non-ascii
-
-comment = comment-start-symbol *non-linefeed
+allowed-comment-char = %x01-%09 / %0E-10FFFF
 
 ;; Key-Value pairs
 
@@ -84,8 +82,9 @@ quotation-mark = %x22            ; "
 
 basic-char = basic-unescaped / escaped
 basic-unescaped = wschar / %x21 / %x23-5B / %x5D-7E / non-ascii
-escaped = escape escape-seq-char
+non-ascii = %x80-D7FF / %xE000-10FFFF
 
+escaped = escape escape-seq-char
 escape = %x5C                   ; \
 escape-seq-char =  %x22         ; "    quotation mark  U+0022
 escape-seq-char =/ %x5C         ; \    reverse solidus U+005C

--- a/toml.md
+++ b/toml.md
@@ -38,14 +38,13 @@ should be easy to parse into data structures in a wide variety of languages.
 
 - TOML is case-sensitive.
 - A TOML file must be a valid UTF-8 encoded Unicode document.
-- Whitespace means tab (0x09) or space (0x20).
-- Newline means LF (0x0A) or CRLF (0x0D 0x0A).
+- Whitespace means tab (U+0009) or space (U+0020).
+- Newline means LF (U+000A) or CRLF (U+000D U+0x0A).
 
 ## Comment
 
 A hash symbol marks the rest of the line as a comment, except when inside a
-string. All valid code points are permitted in a comment, but keep in mind that
-a LF or CRLF terminates the comment.
+string. All valid code points except CR (U+000D) are permitted in a comment.
 
 ```toml
 # This is a full-line comment

--- a/toml.md
+++ b/toml.md
@@ -36,15 +36,10 @@ should be easy to parse into data structures in a wide variety of languages.
 
 ## Spec
 
-A TOML file must be a valid UTF-8 encoded Unicode document. Specifically this
-means that, should a file as a whole not form a
-[well-formed code-unit sequence](https://unicode.org/glossary/#well_formed_code_unit_sequence),
-the file must be rejected (preferably) or ill-formed byte sequences must be
-replaced with U+FFFD as per the Unicode spec.
-
 - TOML is case-sensitive.
-- Whitespace means tab (U+0009) or space (U+0020).
-- Newline means LF (U+000A) or CRLF (U+000D U+000A).
+- A TOML file must be a valid UTF-8 encoded Unicode document.
+- Whitespace means tab (0x09) or space (0x20).
+- Newline means LF (0x0A) or CRLF (0x0D 0x0A).
 
 ## Comment
 
@@ -269,7 +264,7 @@ The above TOML maps to the following JSON.
 ## String
 
 There are four ways to express strings: basic, multi-line basic, literal, and
-multi-line literal. All strings must contain only Unicode characters.
+multi-line literal. All strings must contain only valid Unicode characters.
 
 **Basic strings** are surrounded by quotation marks (`"`). Any Unicode character
 may be used except those that must be escaped: quotation mark, backslash, and
@@ -297,7 +292,7 @@ For convenience, some popular characters have a compact escape sequence.
 ```
 
 Any Unicode character may be escaped with the `\xHH`, `\uHHHH`, or `\UHHHHHHHH`
-forms. The escape codes must be Unicode
+forms. The escape codes must be valid Unicode
 [scalar values](https://unicode.org/glossary/#unicode_scalar_value).
 
 All other escape sequences not listed above are reserved; if they are used, TOML
@@ -421,9 +416,8 @@ str = ''''That,' she said, 'is still pointless.''''
 ```
 
 Control characters other than tab are not permitted in a literal string. Thus,
-for binary data, it is recommended that you use Base64 or another suitable
-binary-to-text encoding. The handling of that encoding will be
-application-specific.
+for binary data, it is recommended that you use Base64 or another suitable ASCII
+or UTF-8 encoding. The handling of that encoding will be application-specific.
 
 ## Integer
 

--- a/toml.md
+++ b/toml.md
@@ -52,8 +52,9 @@ key = "value"  # This is a comment at the end of a line
 another = "# This is not a comment"
 ```
 
-Control characters other than tab (U+0000 to U+0008, U+000A to U+001F, U+007F)
-are not permitted in comments.
+All characters except line feeds (0x0A) are permitted in comments and may be
+ignored. At their discretion, parsers that read comments may exclude a final
+carriage return (0x0D) appearing before a terminating line feed.
 
 ## Key/Value Pair
 

--- a/toml.md
+++ b/toml.md
@@ -37,10 +37,10 @@ should be easy to parse into data structures in a wide variety of languages.
 ## Spec
 
 A TOML file must be a valid UTF-8 encoded Unicode document. Specifically this
-means that, should a file as a whole not form a [well-formed code-unit
-sequence](https://unicode.org/glossary/#well_formed_code_unit_sequence), the
-file must be rejected (preferably) or ill-formed byte sequences must be replaced
-with U+FFFD as per the Unicode spec.
+means that, should a file as a whole not form a
+[well-formed code-unit sequence](https://unicode.org/glossary/#well_formed_code_unit_sequence),
+the file must be rejected (preferably) or ill-formed byte sequences must be
+replaced with U+FFFD as per the Unicode spec.
 
 - TOML is case-sensitive.
 - Whitespace means tab (U+0009) or space (U+0020).

--- a/toml.md
+++ b/toml.md
@@ -36,16 +36,18 @@ should be easy to parse into data structures in a wide variety of languages.
 
 ## Spec
 
+A TOML file must be a valid UTF-8 encoded Unicode document.
+
 - TOML is case-sensitive.
-- A TOML file must be a valid UTF-8 encoded Unicode document.
 - Whitespace means tab (U+0009) or space (U+0020).
 - Newline means LF (U+000A) or CRLF (U+000D U+000A).
 
 ## Comment
 
 A hash symbol marks the rest of the line as a comment, except when inside a
-string. All valid code points except NUL (U+0000) and historic line-breaking
-codes (U+000A through U+000D) are permitted in a comment.
+string. Comments may contain any valid code points except a limited subset of
+ASCII control codes that could cause problems during editing or processing
+(specifically, U+0000, and U+000A to U+000D).
 
 ```toml
 # This is a full-line comment

--- a/toml.md
+++ b/toml.md
@@ -37,9 +37,10 @@ should be easy to parse into data structures in a wide variety of languages.
 ## Spec
 
 A TOML file must be a valid UTF-8 encoded Unicode document. Specifically this
-means that, should a file as a whole not form a well-formed code-unit sequence,
-the file must be rejected (preferably) or ill-formed byte sequences must be
-replaced with U+FFFD as per the Unicode spec.
+means that, should a file as a whole not form a [well-formed code-unit
+sequence](https://unicode.org/glossary/#well_formed_code_unit_sequence), the
+file must be rejected (preferably) or ill-formed byte sequences must be replaced
+with U+FFFD as per the Unicode spec.
 
 - TOML is case-sensitive.
 - Whitespace means tab (U+0009) or space (U+0020).
@@ -420,8 +421,9 @@ str = ''''That,' she said, 'is still pointless.''''
 ```
 
 Control characters other than tab are not permitted in a literal string. Thus,
-for binary data, it is recommended that you use Base64 or another suitable text
-encoding. The handling of that encoding will be application-specific.
+for binary data, it is recommended that you use Base64 or another suitable
+binary-to-text encoding. The handling of that encoding will be
+application-specific.
 
 ## Integer
 

--- a/toml.md
+++ b/toml.md
@@ -44,7 +44,8 @@ should be easy to parse into data structures in a wide variety of languages.
 ## Comment
 
 A hash symbol marks the rest of the line as a comment, except when inside a
-string. All valid code points except CR (U+000D) are permitted in a comment.
+string. All valid code points except NUL (U+0000) and historic line-breaking
+codes (U+000A through U+000D) are permitted in a comment.
 
 ```toml
 # This is a full-line comment

--- a/toml.md
+++ b/toml.md
@@ -39,7 +39,7 @@ should be easy to parse into data structures in a wide variety of languages.
 - TOML is case-sensitive.
 - A TOML file must be a valid UTF-8 encoded Unicode document.
 - Whitespace means tab (U+0009) or space (U+0020).
-- Newline means LF (U+000A) or CRLF (U+000D U+0x0A).
+- Newline means LF (U+000A) or CRLF (U+000D U+000A).
 
 ## Comment
 

--- a/toml.md
+++ b/toml.md
@@ -36,7 +36,10 @@ should be easy to parse into data structures in a wide variety of languages.
 
 ## Spec
 
-A TOML file must be a valid UTF-8 encoded Unicode document.
+A TOML file must be a valid UTF-8 encoded Unicode document. Specifically this
+means that, should a file as a whole not form a well-formed code-unit sequence,
+the file must be rejected (preferably) or ill-formed byte sequences must be
+replaced with U+FFFD as per the Unicode spec.
 
 - TOML is case-sensitive.
 - Whitespace means tab (U+0009) or space (U+0020).
@@ -45,9 +48,9 @@ A TOML file must be a valid UTF-8 encoded Unicode document.
 ## Comment
 
 A hash symbol marks the rest of the line as a comment, except when inside a
-string. Comments may contain any valid code points except a limited subset of
-ASCII control codes that could cause problems during editing or processing
-(specifically, U+0000, and U+000A to U+000D).
+string. Comments may contain any Unicode code points except the following
+control codes that could cause problems during editing or processing: U+0000,
+and U+000A to U+000D.
 
 ```toml
 # This is a full-line comment
@@ -265,7 +268,7 @@ The above TOML maps to the following JSON.
 ## String
 
 There are four ways to express strings: basic, multi-line basic, literal, and
-multi-line literal. All strings must contain only valid UTF-8 characters.
+multi-line literal. All strings must contain only Unicode characters.
 
 **Basic strings** are surrounded by quotation marks (`"`). Any Unicode character
 may be used except those that must be escaped: quotation mark, backslash, and
@@ -293,8 +296,8 @@ For convenience, some popular characters have a compact escape sequence.
 ```
 
 Any Unicode character may be escaped with the `\xHH`, `\uHHHH`, or `\UHHHHHHHH`
-forms. The escape codes must be valid Unicode
-[scalar values](https://unicode.org/glossary/#unicode_scalar_value).
+forms. The escape codes must be Unicode [scalar
+values](https://unicode.org/glossary/#unicode_scalar_value).
 
 All other escape sequences not listed above are reserved; if they are used, TOML
 should produce an error.
@@ -417,8 +420,8 @@ str = ''''That,' she said, 'is still pointless.''''
 ```
 
 Control characters other than tab are not permitted in a literal string. Thus,
-for binary data, it is recommended that you use Base64 or another suitable ASCII
-or UTF-8 encoding. The handling of that encoding will be application-specific.
+for binary data, it is recommended that you use Base64 or another suitable text
+encoding. The handling of that encoding will be application-specific.
 
 ## Integer
 

--- a/toml.md
+++ b/toml.md
@@ -52,9 +52,10 @@ key = "value"  # This is a comment at the end of a line
 another = "# This is not a comment"
 ```
 
-Comments may contain any Unicode code points except the following
-control codes that could cause problems during editing or processing: U+0000,
-and U+000A to U+000D.
+Comments may contain any Unicode code points except the following control codes
+that could cause problems during editing or processing: U+0000, and U+000A to
+U+000D.
+
 ## Key/Value Pair
 
 The primary building block of a TOML document is the key/value pair.

--- a/toml.md
+++ b/toml.md
@@ -44,7 +44,8 @@ should be easy to parse into data structures in a wide variety of languages.
 ## Comment
 
 A hash symbol marks the rest of the line as a comment, except when inside a
-string. All code points except line feeds (U+000A) are permitted in comments.
+string. All valid code points are permitted in a comment, but keep in mind that
+a LF or CRLF terminates the comment.
 
 ```toml
 # This is a full-line comment

--- a/toml.md
+++ b/toml.md
@@ -296,8 +296,8 @@ For convenience, some popular characters have a compact escape sequence.
 ```
 
 Any Unicode character may be escaped with the `\xHH`, `\uHHHH`, or `\UHHHHHHHH`
-forms. The escape codes must be Unicode [scalar
-values](https://unicode.org/glossary/#unicode_scalar_value).
+forms. The escape codes must be Unicode
+[scalar values](https://unicode.org/glossary/#unicode_scalar_value).
 
 All other escape sequences not listed above are reserved; if they are used, TOML
 should produce an error.

--- a/toml.md
+++ b/toml.md
@@ -44,17 +44,13 @@ should be easy to parse into data structures in a wide variety of languages.
 ## Comment
 
 A hash symbol marks the rest of the line as a comment, except when inside a
-string.
+string. All code points except line feeds (U+000A) are permitted in comments.
 
 ```toml
 # This is a full-line comment
 key = "value"  # This is a comment at the end of a line
 another = "# This is not a comment"
 ```
-
-All characters except line feeds (0x0A) are permitted in comments and may be
-ignored. At their discretion, parsers that read comments may exclude a final
-carriage return (0x0D) appearing before a terminating line feed.
 
 ## Key/Value Pair
 

--- a/toml.md
+++ b/toml.md
@@ -44,9 +44,7 @@ should be easy to parse into data structures in a wide variety of languages.
 ## Comment
 
 A hash symbol marks the rest of the line as a comment, except when inside a
-string. Comments may contain any Unicode code points except the following
-control codes that could cause problems during editing or processing: U+0000,
-and U+000A to U+000D.
+string.
 
 ```toml
 # This is a full-line comment
@@ -54,6 +52,9 @@ key = "value"  # This is a comment at the end of a line
 another = "# This is not a comment"
 ```
 
+Comments may contain any Unicode code points except the following
+control codes that could cause problems during editing or processing: U+0000,
+and U+000A to U+000D.
 ## Key/Value Pair
 
 The primary building block of a TOML document is the key/value pair.


### PR DESCRIPTION
In reconsideration of the limitation of control codes within comments discussed in #567, a case was made to simplify comment parsing. This PR intends to replace those previously imposed restrictions with a simplified approach that permits anything except newlines.