### PR TITLE
Clarify Unicode and UTF-8 references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Clarify Unicode and UTF-8 references.
 - Allow newline after key/values in inline tables.
 - Allow trailing comma in inline tables.
 - Clarify where and how dotted keys define tables.

--- a/toml.md
+++ b/toml.md
@@ -36,10 +36,15 @@ should be easy to parse into data structures in a wide variety of languages.
 
 ## Spec
 
+A TOML file must be a valid UTF-8 encoded Unicode document. Specifically this
+means that, should a file as a whole not form a
+[well-formed code-unit sequence](https://unicode.org/glossary/#well_formed_code_unit_sequence),
+the file must be rejected (preferably) or ill-formed byte sequences must be
+replaced with U+FFFD as per the Unicode spec.
+
 - TOML is case-sensitive.
-- A TOML file must be a valid UTF-8 encoded Unicode document.
-- Whitespace means tab (0x09) or space (0x20).
-- Newline means LF (0x0A) or CRLF (0x0D 0x0A).
+- Whitespace means tab (U+0009) or space (U+0020).
+- Newline means LF (U+000A) or CRLF (U+000D U+000A).
 
 ## Comment
 
@@ -265,7 +270,7 @@ The above TOML maps to the following JSON.
 ## String
 
 There are four ways to express strings: basic, multi-line basic, literal, and
-multi-line literal. All strings must contain only valid UTF-8 characters.
+multi-line literal. All strings must contain only Unicode characters.
 
 **Basic strings** are surrounded by quotation marks (`"`). Any Unicode character
 may be used except those that must be escaped: quotation mark, backslash, and
@@ -293,7 +298,7 @@ For convenience, some popular characters have a compact escape sequence.
 ```
 
 Any Unicode character may be escaped with the `\xHH`, `\uHHHH`, or `\UHHHHHHHH`
-forms. The escape codes must be valid Unicode
+forms. The escape codes must be Unicode
 [scalar values](https://unicode.org/glossary/#unicode_scalar_value).
 
 All other escape sequences not listed above are reserved; if they are used, TOML
@@ -417,8 +422,9 @@ str = ''''That,' she said, 'is still pointless.''''
 ```
 
 Control characters other than tab are not permitted in a literal string. Thus,
-for binary data, it is recommended that you use Base64 or another suitable ASCII
-or UTF-8 encoding. The handling of that encoding will be application-specific.
+for binary data, it is recommended that you use Base64 or another suitable
+binary-to-text encoding. The handling of that encoding will be
+application-specific.
 
 ## Integer
 

--- a/toml.md
+++ b/toml.md
@@ -299,10 +299,12 @@ For convenience, some popular characters have a compact escape sequence.
 
 Any Unicode character may be escaped with the `\xHH`, `\uHHHH`, or `\UHHHHHHHH`
 forms. The escape codes must be Unicode
-[scalar values](https://unicode.org/glossary/#unicode_scalar_value). Note that
-there is no low-level byte sequence syntax in TOML, and that these escape codes
-must not be made to work in such a way. So for binary data, it is recommended
-that you use Base64 or another binary-to-text encoding.
+[scalar values](https://unicode.org/glossary/#unicode_scalar_value).
+
+Note that there is no low-level byte sequence syntax in TOML, and that the
+character escape codes must not be made to work in such a way. So for binary
+data, it is recommended that you use Base64 or another binary-to-text encoding,
+and that external tools ought to be used to interpret such encodings.
 
 All other escape sequences not listed above are reserved; if they are used, TOML
 should produce an error.

--- a/toml.md
+++ b/toml.md
@@ -301,10 +301,11 @@ Any Unicode character may be escaped with the `\xHH`, `\uHHHH`, or `\UHHHHHHHH`
 forms. The escape codes must be Unicode
 [scalar values](https://unicode.org/glossary/#unicode_scalar_value).
 
-Note that there is no low-level byte sequence syntax in TOML, and that the
-character escape codes must not be made to work in such a way. So for binary
-data, it is recommended that you use Base64 or another binary-to-text encoding,
-and that external tools ought to be used to interpret such encodings.
+Keep in mind that all TOML strings are sequences of Unicode characters, _not_
+byte sequences. For binary data, avoid using these escape codes. Instead,
+external binary-to-text encoding strategies, like hexadecimal sequences or
+[Base64](https://www.base64decode.org/), are recommended for converting between
+bytes and strings.
 
 All other escape sequences not listed above are reserved; if they are used, TOML
 should produce an error.

--- a/toml.md
+++ b/toml.md
@@ -36,15 +36,15 @@ should be easy to parse into data structures in a wide variety of languages.
 
 ## Preliminaries
 
-A TOML file must be a valid UTF-8 encoded Unicode document. Specifically this
-means that, should a file as a whole not form a
-[well-formed code-unit sequence](https://unicode.org/glossary/#well_formed_code_unit_sequence),
-the file must be rejected (preferably) or ill-formed byte sequences must be
-replaced with U+FFFD as per the Unicode specification.
-
 - TOML is case-sensitive.
 - Whitespace means tab (U+0009) or space (U+0020).
 - Newline means LF (U+000A) or CRLF (U+000D U+000A).
+- A TOML file must be a valid UTF-8 encoded Unicode document.
+
+  Specifically this means that a file _as a whole_ must form a
+  [well-formed code-unit sequence](https://unicode.org/glossary/#well_formed_code_unit_sequence)
+  and will be rejected (preferably) or have ill-formed byte sequences replaced
+  with U+FFFD as per the Unicode specification.
 
 ## Comment
 

--- a/toml.md
+++ b/toml.md
@@ -14,7 +14,7 @@ should be easy to parse into data structures in a wide variety of languages.
 
 ## Table of contents
 
-- [Spec](#user-content-spec)
+- [Preliminaries](#user-content-preliminaries)
 - [Comment](#user-content-comment)
 - [Key/Value Pair](#user-content-keyvalue-pair)
 - [Keys](#user-content-keys)
@@ -34,13 +34,13 @@ should be easy to parse into data structures in a wide variety of languages.
 - [MIME Type](#user-content-mime-type)
 - [ABNF Grammar](#user-content-abnf-grammar)
 
-## Spec
+## Preliminaries
 
 A TOML file must be a valid UTF-8 encoded Unicode document. Specifically this
 means that, should a file as a whole not form a
 [well-formed code-unit sequence](https://unicode.org/glossary/#well_formed_code_unit_sequence),
 the file must be rejected (preferably) or ill-formed byte sequences must be
-replaced with U+FFFD as per the Unicode spec.
+replaced with U+FFFD as per the Unicode specification.
 
 - TOML is case-sensitive.
 - Whitespace means tab (U+0009) or space (U+0020).

--- a/toml.md
+++ b/toml.md
@@ -423,8 +423,7 @@ str = ''''That,' she said, 'is still pointless.''''
 
 Control characters other than tab are not permitted in a literal string. Thus,
 for binary data, it is recommended that you use Base64 or another suitable
-binary-to-text encoding. The handling of that encoding will be
-application-specific.
+binary-to-text encoding.
 
 ## Integer
 

--- a/toml.md
+++ b/toml.md
@@ -299,7 +299,10 @@ For convenience, some popular characters have a compact escape sequence.
 
 Any Unicode character may be escaped with the `\xHH`, `\uHHHH`, or `\UHHHHHHHH`
 forms. The escape codes must be Unicode
-[scalar values](https://unicode.org/glossary/#unicode_scalar_value).
+[scalar values](https://unicode.org/glossary/#unicode_scalar_value). Note that
+there is no low-level byte sequence syntax in TOML, and that these escape codes
+must not be made to work in such a way. So for binary data, it is recommended
+that you use Base64 or another binary-to-text encoding.
 
 All other escape sequences not listed above are reserved; if they are used, TOML
 should produce an error.
@@ -421,9 +424,7 @@ apos15 = "Here are fifteen apostrophes: '''''''''''''''"
 str = ''''That,' she said, 'is still pointless.''''
 ```
 
-Control characters other than tab are not permitted in a literal string. Thus,
-for binary data, it is recommended that you use Base64 or another suitable
-binary-to-text encoding.
+Control characters other than tab are not permitted in a literal string.
 
 ## Integer
 


### PR DESCRIPTION
This PR applies the changes to clarify Unicode and UTF-8 references, done originally for #924 while considering relaxations on control code in comments. These are standalone changes, separate from the original scope of #924. Many thanks to @abelbraaksma and @ChristianSi for their work on this.