### PR TITLE
Clarify that comments never affect the tables produced by parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Clarify that comments never affect the tables produced by parsers.
 - Allow newline after key/values in inline tables.
 - Allow trailing comma in inline tables.
 - Clarify where and how dotted keys define tables.

--- a/toml.md
+++ b/toml.md
@@ -43,6 +43,9 @@ should be easy to parse into data structures in a wide variety of languages.
 
 ## Comment
 
+Comments provide notes to the TOML document's users. They never affect the
+resulting table produced by parsers.
+
 A hash symbol marks the rest of the line as a comment, except when inside a
 string.
 


### PR DESCRIPTION
In the discussion on #603, it became clear that no restrictions are placed on parsers that could further modify the hash tables that they generate based on included comments. The purpose of this PR is to assure that parsers will never modify a TOML document's resulting hash table due to the presence or contents of the comments contained within the document.

The change to `toml.md` will prevent a certain class of abuses of the TOML syntax, without prohibiting comment-preserving parsers from doing their thing (as those comments are not part of the resulting table but merely reference it from locations in the source document).