### PR TITLE
Clarify that comments never affect the tables produced by parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 
+- Clarify that comments never affect the tables produced by parsers.
 - Clarify Unicode and UTF-8 references.
 - Relax comment parsing; most control characters are again permitted.
 - Allow newline after key/values in inline tables.

--- a/toml.md
+++ b/toml.md
@@ -61,6 +61,10 @@ Comments may contain any Unicode code points except the following control codes
 that could cause problems during editing or processing: U+0000, and U+000A to
 U+000D.
 
+Comments are not considered part of the table that the document describes, and
+parsers must never be affected by the presence, or contents, of comments within
+the file when generating that table.
+
 ## Key/Value Pair
 
 The primary building block of a TOML document is the key/value pair.

--- a/toml.md
+++ b/toml.md
@@ -61,9 +61,9 @@ Comments may contain any Unicode code points except the following control codes
 that could cause problems during editing or processing: U+0000, and U+000A to
 U+000D.
 
-Comments are not considered part of the table that the document describes, and
-parsers must never be affected by the presence, or contents, of comments within
-the file when generating that table.
+Comments should be used to communicate between the human readers of a file.
+Parsers must not modify keys or values, based on the presence (or contents) of a
+comment.
 
 ## Key/Value Pair
 


### PR DESCRIPTION
In the discussion on #603, it became clear that no restrictions are placed on parsers that could further modify the hash tables that they generate based on included comments. The purpose of this PR is to assure that parsers will never modify a TOML document's resulting hash table due to the presence or contents of the comments contained within the document.

The change to `toml.md` will prevent a certain class of abuses of the TOML syntax, without prohibiting comment-preserving parsers from doing their thing (as those comments are not part of the resulting table but merely reference it from locations in the source document).

(This PR replaces #948.)