### PR TITLE
toml.md: Add apostrophe example for multi-line literal strings

### DIFF
--- a/toml.md
+++ b/toml.md
@@ -407,6 +407,7 @@ modification.
 
 ```toml
 regex2 = '''I [dw]on't need \d{2} apples'''
+literal-apostrophes = '''You're free to use apostrophes in here.'''
 lines  = '''
 The first newline is
 trimmed in raw strings.


### PR DESCRIPTION
When I [pointed to the website](https://github.com/toml-lang/toml/issues/949#issuecomment-1377864878) when discussing how apostrophes are permitted in multi-line literal strings, I was surprised to discover that this permission is described, but it isn't made explicitly clear with an example.

This change adds such an example.

```toml
literal-apostrophes = '''You're free to use apostrophes in here.'''
```

This replaces a [PR on toml-lang/toml.io](https://github.com/toml-lang/toml.io/pull/61), created before I realized that the front page to https://toml.io is generated.