### PR TITLE
Change wording for literal string in example

### DIFF
--- a/toml.md
+++ b/toml.md
@@ -409,7 +409,7 @@ modification.
 regex2 = '''I [dw]on't need \d{2} apples'''
 lines  = '''
 The first newline is
-trimmed in raw strings.
+trimmed in literal strings.
    All other whitespace
    is preserved.
 '''


### PR DESCRIPTION
This corrects an instance of the wrong terminology being used to describe the nature of multi-line literal strings. The original author wrote "raw strings" in the example, but TOML doesn't have "raw" strings, but rather, "literal" strings.