### PR TITLE
Capitalize the unicodes in `toml.abnf`

### DIFF
--- a/toml.abnf
+++ b/toml.abnf
@@ -163,8 +163,8 @@ exp = "e" float-exp-part
 float-exp-part = [ minus / plus ] zero-prefixable-int
 
 special-float = [ minus / plus ] ( inf / nan )
-inf = %x69.6e.66  ; inf
-nan = %x6e.61.6e  ; nan
+inf = %x69.6E.66  ; inf
+nan = %x6E.61.6E  ; nan
 
 ;; Boolean
 


### PR DESCRIPTION
I suppose that the `6e` here should be capitalized like other unicodes in the file.
This change unifies the file without affecting any of the syntax.