### PR TITLE
Clarify that key comparison is ordinal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## unreleased
 
+- Clarify that comparison for quoted keys is ordinal and doesn't do Unicode
+  normalization ([#993])
+
 - Clarify that tables typically cannot be nested infinitely [#1087]).
 
+[#993]: https://github.com/toml-lang/toml/pull/993
 [#1087]: https://github.com/toml-lang/toml/pull/1087
 
 ## 1.1.0 / 2025-12-18

--- a/toml.md
+++ b/toml.md
@@ -194,6 +194,20 @@ spelling = "favorite"
 "spelling" = "favourite"
 ```
 
+Keys are considered identical if their code point sequences are the same. It is
+possible to create distinct keys that appear visually identical. Doing so is
+discouraged:
+
+```toml
+# VALID BUT DISCOURAGED
+
+# prénom = "Françoise", using NFC
+"pr\u00e9nom" = "Françoise"
+
+# prénom = "Françoise", using NFD
+"pr\u0065\u0301nom" = "Françoise"
+```
+
 As long as a key hasn't been directly defined, you may still write to it and to
 names within it.
 

--- a/toml.md
+++ b/toml.md
@@ -201,11 +201,11 @@ discouraged:
 ```toml
 # VALID BUT DISCOURAGED
 
-# prénom = "Françoise", using NFC
-"pr\u00e9nom" = "Françoise"
+# prénom = "Françoise", using pre-composed LATIN SMALL LETTER E WITH ACUTE (U+00E9, NFC)
+"pr\xe9nom" = "Françoise"
 
-# prénom = "Françoise", using NFD
-"pr\u0065\u0301nom" = "Françoise"
+# prénom = "Françoise", using COMBINING ACUTE ACCENT (U+0301, NFD)
+"pre\u0301nom" = "Françoise"
 ```
 
 As long as a key hasn't been directly defined, you may still write to it and to

--- a/toml.md
+++ b/toml.md
@@ -194,9 +194,9 @@ spelling = "favorite"
 "spelling" = "favourite"
 ```
 
-Keys are considered identical if their code point sequences are the same. It is
-possible to create distinct keys that appear visually identical. Doing so is
-discouraged:
+Quoted keys are considered identical if their code point sequences are the same.
+It is possible to create distinct keys that appear visually identical. Doing so
+is discouraged:
 
 ```toml
 # VALID BUT DISCOURAGED


### PR DESCRIPTION
@SnoopJ identified in #966 that the TOML spec does not specify how keys are compared. We've discussed the matter to death at this point, and if I never hear the word "normalization" again it'll be too soon 😅, but to recap:

1. Requiring normalization imposes significant implementation burden, and shuts out people who may explicitly not want that behaviour
2. Recommending (but not requiring) normalization creates ecosystem fragmentation and round-trip issues
3. Not saying anything about it at all leaves an ambiguous hole in the spec

So I'm taking @eksortso's proposal in his comment in #966 and running with it. This is not intended to complete with @arp242's #990 - they're orthogonal, really. Regardless of what we decide RE normalization (or lack thereof), we should say _something_ about how keys are treated during comparison.

This also somewhat strengthens the idea that keys are just strings. Since they can be specified using string syntax, there's really no argument to be made for treating them as anything else anyway, IMO. TOML isn't a programming language.

Closes #966