### PR TITLE
Clarify integer size and float precision levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@
 
 - Clarify sub-millisecond precision is allowed ([#805]).
 
+- Clarify that parsers are free to support any int or float size ([#1058]).
+
 [#790]: https://github.com/toml-lang/toml/pull/790
 [#796]: https://github.com/toml-lang/toml/pull/796
 [#805]: https://github.com/toml-lang/toml/pull/805
@@ -47,6 +49,7 @@
 [#904]: https://github.com/toml-lang/toml/pull/904
 [#929]: https://github.com/toml-lang/toml/pull/929
 [#950]: https://github.com/toml-lang/toml/pull/950
+[#1058]: https://github.com/toml-lang/toml/pull/1058
 
 ## 1.0.0 / 2021-01-11
 

--- a/toml.md
+++ b/toml.md
@@ -464,13 +464,12 @@ oct2 = 0o755 # useful for Unix file permissions
 bin1 = 0b11010110
 ```
 
-Arbitrary 64-bit signed integers (from −2^63 to 2^63−1) should be accepted and
-handled losslessly. If an integer cannot be represented losslessly, an error
-must be thrown.
+Implementations are free to support any integer size. It's recommended that at
+least 64-bit signed integers (from −2^63 to 2^63−1) are accepted and handled
+losslessly. If an integer cannot be represented losslessly, an error must be
+thrown.
 
 ## Float
-
-Floats should be implemented as IEEE 754 binary64 values.
 
 A float consists of an integer part (which follows the same rules as decimal
 integer values) followed by a fractional part and/or an exponent part. If both a
@@ -530,6 +529,9 @@ sf4 = nan  # actual sNaN/qNaN encoding is implementation-specific
 sf5 = +nan # same as `nan`
 sf6 = -nan # valid, actual encoding is implementation-specific
 ```
+
+Implementations are free to support any precision level. It's recommended that
+at least IEEE 754 binary64 values are supported.
 
 ## Boolean
 


### PR DESCRIPTION
"Should" is one of those ambiguous terms that can mean any number of things. We never strictly define what "should" means.

This clarifies things so that it's obvious that any size can be supported, but that 64bit sizes are recommended.

Fixes #1029