### PR TITLE
Remove spurious line referring to code points

### DIFF
--- a/toml.md
+++ b/toml.md
@@ -110,9 +110,6 @@ A key may be either bare, quoted, or dotted.
 dashes (`A-Za-z0-9_-`). Note that bare keys are allowed to be composed of only
 ASCII digits, e.g. `1234`, but are always interpreted as strings.
 
-&#x2139;&#xfe0f; The exact ranges of allowed code points can be found in the
-[ABNF grammar file][abnf].
-
 ```toml
 key = "value"
 bare_key = "value"


### PR DESCRIPTION
It's a leftover from the backed-out attempt to introduce Unicode bare keys and so completes #979.

@arp242, @pradyunsg : Can you take a look and approve?