### PR TITLE
Fix duplicate keys in doc introduced in 1.1

### DIFF
--- a/toml.md
+++ b/toml.md
@@ -558,15 +558,15 @@ For the sake of readability, you may replace the T delimiter between date and
 time with a space character (as permitted by RFC 3339 section 5.6).
 
 ```toml
-odt4 = 1979-05-27 07:32:00Z
+odt5 = 1979-05-27 07:32:00Z
 ```
 
 One exception to RFC 3339 is permitted: seconds may be omitted, in which case
 `:00` will be assumed. The offset immediately follows the minutes.
 
 ```toml
-odt5 = 1979-05-27 07:32Z
-odt6 = 1979-05-27 07:32-07:00
+odt6 = 1979-05-27 07:32Z
+odt7 = 1979-05-27 07:32-07:00
 ```
 
 Implementations are required to support at least millisecond precision.
@@ -590,7 +590,7 @@ ldt3 = 1979-05-27T00:32:00.999999
 Seconds may be omitted, in which case `:00` will be assumed.
 
 ```toml
-ldt3 = 1979-05-27T07:32
+ldt4 = 1979-05-27T07:32
 ```
 
 Implementations are required to support at least millisecond precision.
@@ -623,7 +623,7 @@ lt3 = 00:32:00.999999
 Seconds may be omitted, in which case `:00` will be assumed.
 
 ```toml
-lt3 = 07:32
+lt4 = 07:32
 ```
 
 Implementations are required to support at least millisecond precision.


### PR DESCRIPTION
1.1 introduced optional seconds for time and datetimes. The examples that were added are nicely updated to be sequential within the code block, but caused keys to duplicate with following code blocks. This is inconsistent with the rest of the document which avoids duplicated keys. Also it just looks odd to randomly have a odt4 again.