### PR TITLE
Add paragraph about table nesting depth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # TOML Changelog
 
+## unreleased
+
+- Clarify that tables typically cannot be nested infinitely [#1087]).
+
+[#1087]: https://github.com/toml-lang/toml/pull/1087
+
 ## 1.1.0 / 2025-12-18
 
 - Allow newlines and trailing commas in inline tables ([#904]).

--- a/toml.md
+++ b/toml.md
@@ -705,6 +705,10 @@ In JSON land, that would give you the following structure:
 { "dog": { "tater.man": { "type": { "name": "pug" } } } }
 ```
 
+There is no limit on the nesting depth. However, in practice most
+implementations impose some limit to prevent excessive resource usage and/or
+crashes. It's recommended to allow at least 100 levels of nesting.
+
 Whitespace around the key is ignored. However, best practice is to not use any
 extraneous whitespace.
 


### PR DESCRIPTION
Recently there have been a few TOML implementations that have added a nesting limit depth to prevent using up huge amount of CPU/memory with a document like "a.«10,000 more» = 1". For example:

https://github.com/hukkin/tomli/pull/286
https://github.com/python-poetry/tomlkit/pull/468
https://github.com/BurntSushi/toml/commit/2e90ced6

There's probably more. In a casual quick look, many implementations already have such a limit and if they don't, they probably should.

I added a comment in the toml-test README for it, but I think mentioning it in the spec would also be useful. If only to set a recommended lower limit like we do for 64bit ints. This is helpful both for implementation authors (as a reminder they should add such a limit) and users (as a reminder there may be a limit).

For example BurntSushi/toml has never had such a limit until recently, even though I've always known this sort of thing is a problem. I ... just never thought of it. This would have been fixed years ago if there had been a comment in the spec. That's probably the same for tomli.