### PR TITLE
Analysis of TOML Design Principles

### DIFF
--- a/docs/design_principles_analysis.md
+++ b/docs/design_principles_analysis.md
@@ -1,0 +1,19 @@
+# Analysis of TOML Design Principles
+
+This document provides a concise analysis of the three core design principles of TOML (Tom's Obvious Minimal Language) as stated in the official specification. These principles guide every aspect of the language's design and differentiate TOML from other configuration file formats.
+
+## 1. Obvious Semantics — Easy to Read
+
+TOML's first principle is that it should be easy to read due to obvious semantics. This means that anyone looking at a TOML file should be able to immediately understand what it represents without consulting external documentation or learning obscure syntax rules. The format uses straightforward key-value pairs, tables denoted by headers in square brackets, and arrays represented with familiar bracket notation. By favoring clarity over brevity, TOML ensures that configuration files serve as self-documenting artifacts. This readability-first philosophy contrasts with formats like JSON, which, while human-readable, can become visually cluttered with nested braces and quotation marks, or YAML, which relies on significant indentation that can introduce subtle errors.
+
+## 2. Unambiguous Mapping to a Hash Table
+
+The second principle states that TOML is designed to map unambiguously to a hash table. Every valid TOML document corresponds to a single, well-defined data structure — a dictionary or map where keys are strings and values can be various primitive types, nested tables, or arrays. There is no ambiguity in how a TOML document should be interpreted; a given TOML file always resolves to exactly one hash table representation. This eliminates the parsing confusion that can arise in formats like YAML, where the same input can sometimes be interpreted in multiple ways (e.g., the famous "Norway problem" with country codes being parsed as booleans). The one-to-one mapping ensures consistency and reliability across all implementations.
+
+## 3. Easy to Parse into Data Structures Across Languages
+
+The third principle emphasizes that TOML should be easy to parse into data structures in a wide variety of languages. This cross-language accessibility is critical for a configuration format, as different projects and ecosystems use different programming languages. The specification is intentionally kept minimal and well-defined so that implementing a parser in any language is straightforward. The grammar is simple enough that a complete parser can be written in a few hundred lines of code, yet expressive enough to handle the data modeling needs of typical configuration scenarios. This practical focus on implementability has contributed to TOML's rapid adoption across ecosystems including Rust (Cargo), Python (PEP 518), Go, and many others.
+
+## Conclusion
+
+Together, these three principles — obvious readability, unambiguous data mapping, and cross-language parsability — form a cohesive design philosophy that prioritizes practicality and correctness. They explain why TOML has emerged as a popular choice for configuration files in modern software development, offering a thoughtful balance between human ergonomics and machine processability.


### PR DESCRIPTION
## Addition: Analysis of TOML Design Principles

This PR adds a new Markdown file at `docs/design_principles_analysis.md` that provides a concise analysis (approximately 300-500 words) of the three core design principles of TOML as stated in the official specification document (`toml.md`).

The analysis covers:

1. **Obvious Semantics — Easy to Read**: How TOML prioritizes readability through straightforward syntax that is self-documenting.
2. **Unambiguous Mapping to a Hash Table**: How every TOML document maps cleanly and unambiguously to a single hash table representation, eliminating interpretation ambiguity.
3. **Easy to Parse Across Languages**: How TOML's minimal, well-defined grammar makes it straightforward to implement parsers in any programming language.

This document is intended as a supplementary reference for understanding the philosophical foundations of TOML's design.