### PR TITLE
Analysis of TOML Design Principles

### DIFF
--- a/docs/design_principles_analysis.md
+++ b/docs/design_principles_analysis.md
@@ -1,0 +1,19 @@
+# Analysis of TOML Design Principles
+
+TOML (Tom's Obvious Minimal Language) is a configuration file format whose specification articulates three core design principles that distinguish it from other formats like YAML, JSON, or INI. This document provides a concise analysis of each principle.
+
+## 1. Minimal and Easy to Read with Obvious Semantics
+
+The first principle states that TOML aims to be a minimal configuration file format that is easy to read due to obvious semantics. This means that anyone encountering a TOML file should be able to understand its structure and meaning at a glance, without needing to consult documentation or reason about ambiguous syntax. Unlike YAML, which has a notoriously complex specification with many edge cases and surprising behaviors (such as implicit type coercion), TOML deliberately keeps its syntax simple and predictable. Key-value pairs, tables, and arrays of tables follow straightforward patterns that mirror how one would naturally write down configuration data. The emphasis on "obvious semantics" ensures that the format behaves as a reasonable person would expect, reducing the likelihood of misinterpretation or errors.
+
+## 2. Maps Unambiguously to a Hash Table
+
+The second principle requires that TOML maps unambiguously to a hash table. This is a critical design choice that eliminates the ambiguity found in formats like YAML, where the same document can be interpreted in multiple ways depending on the parser. In TOML, every valid document has exactly one correct interpretation as a key-value mapping (a dictionary, map, or hash table, depending on your language of choice). This one-to-one correspondence between a TOML document and its data representation means that different parsers in different languages will always produce equivalent data structures from the same input. It also means that the hierarchy of tables and sub-tables has a clear, deterministic mapping to nested hash tables, making the format both predictable and reliable for programmatic use.
+
+## 3. Easy to Parse into Data Structures in a Wide Variety of Languages
+
+The third principle states that TOML should be easy to parse into data structures in a wide variety of languages. This portability goal recognizes that configuration files are consumed by applications written in many different programming languages, and a good configuration format should not favor one ecosystem over another. By designing the format around universal data types—strings, integers, floats, booleans, arrays, and hash tables—TOML ensures that every major programming language can naturally represent TOML data without awkward conversions or loss of fidelity. The grammar is intentionally kept simple to lower the barrier for parser implementers, which has resulted in a rich ecosystem of compliant parsers across virtually every popular language. This principle also discourages the addition of features that would be difficult to represent in some languages, keeping the format grounded in practical interoperability.
+
+## Conclusion
+
+Together, these three principles—readability through obvious semantics, unambiguous hash table mapping, and cross-language parsability—form a cohesive design philosophy that prioritizes clarity, consistency, and practicality. They work in concert: the minimal syntax (Principle 1) contributes to unambiguous mapping (Principle 2), which in turn facilitates easy parsing across languages (Principle 3). This unified approach has made TOML a popular choice for configuration files in projects ranging from Rust's Cargo to Python's pyproject.toml.


### PR DESCRIPTION
## Summary

This PR adds a concise analysis of the three core design principles of TOML as stated in the official specification document (`toml.md`). The analysis is provided in a new Markdown file at `docs/design_principles_analysis.md`.

### The three principles analyzed:

1. **Minimal and easy to read with obvious semantics** — TOML's syntax is deliberately simple and predictable, avoiding the complexity and ambiguity found in other formats like YAML.

2. **Maps unambiguously to a hash table** — Every valid TOML document has exactly one correct interpretation as a key-value mapping, eliminating parser ambiguity.

3. **Easy to parse into data structures in a wide variety of languages** — By relying on universal data types and a simple grammar, TOML ensures broad cross-language interoperability.

The analysis explains each principle in its own words and discusses how they work together to form a cohesive design philosophy prioritizing clarity, consistency, and practicality.