### PR TITLE
Analysis of TOML Design Principles

### DIFF
--- a/docs/design_principles_analysis.md
+++ b/docs/design_principles_analysis.md
@@ -1,0 +1,19 @@
+# Analysis of TOML Design Principles
+
+This document provides a concise analysis of the three core design principles of TOML as stated in the official specification.
+
+## 1. Easy to Read with Obvious Semantics
+
+The first principle asserts that TOML should be a minimal configuration file format that is easy to read due to obvious semantics. This means that anyone looking at a TOML file should be able to understand its structure and meaning at a glance, without needing to consult external documentation. The format achieves this through straightforward key-value pairs, intuitive section headers using square brackets, and a syntax that closely resembles common conventions already familiar to developers. By prioritizing human readability above all else, TOML ensures that configuration files remain accessible even to those who are not deeply technical, reducing the cognitive burden of managing application settings.
+
+## 2. Unambiguous Mapping to a Hash Table
+
+The second principle states that TOML is designed to map unambiguously to a hash table. This is a critical design decision that ensures every valid TOML document corresponds to exactly one data structure representation. There is no room for interpretation or ambiguity in how the data should be organized. Keys map to values, and tables (sections) map to nested hash tables. This one-to-one correspondence eliminates the parsing ambiguities that plague some other formats, where the same document could be interpreted in multiple ways depending on the parser. For developers, this means they can confidently predict the exact data structure that will result from parsing any given TOML file, making the format reliable for programmatic use across all implementations.
+
+## 3. Easy to Parse into Data Structures Across Languages
+
+The third principle emphasizes that TOML should be easy to parse into data structures in a wide variety of languages. Rather than pushing the boundaries of what a configuration format can express, TOML deliberately constrains its feature set to data types that have natural equivalents in virtually every programming language: strings, integers, floats, booleans, arrays, and tables. This pragmatic approach ensures that writing a TOML parser is straightforward and that the parsed output can be represented natively in the target language without requiring complex transformations or lossy conversions. The result is a format that fosters broad ecosystem support, with consistent, reliable implementations available across many programming environments.
+
+## Conclusion
+
+Together, these three principles — readability, unambiguous data mapping, and cross-language parsability — form a cohesive design philosophy that positions TOML as a practical, no-surprises configuration format. By adhering to these goals, TOML avoids the complexity and ambiguity that can arise in more feature-rich formats, instead providing a dependable tool for the specific task of representing configuration data clearly and consistently.


### PR DESCRIPTION
## Addition: Design Principles Analysis

This pull request adds a new document at `docs/design_principles_analysis.md` that provides a concise analysis of the three core design principles of TOML as stated in the official specification (`toml.md`).

The analysis covers:

1. **Easy to Read with Obvious Semantics** — How TOML prioritizes human readability through intuitive syntax.
2. **Unambiguous Mapping to a Hash Table** — How TOML ensures every valid document corresponds to exactly one data structure.
3. **Easy to Parse into Data Structures Across Languages** — How TOML's constrained type system enables broad cross-language support.

This document serves as a supplementary reference for understanding the philosophy behind TOML's design decisions.