### PR TITLE
Analysis of TOML Design Principles

### DIFF
--- a/docs/design_principles_analysis.md
+++ b/docs/design_principles_analysis.md
@@ -1,0 +1,19 @@
+# Analysis of TOML Design Principles
+
+The TOML specification outlines three core design principles in its Objectives section. This document provides a concise analysis of each principle and its implications for the language's design and usage.
+
+## 1. Minimal Configuration File Format
+
+TOML is intentionally designed to be a *minimal* format. Unlike general-purpose data serialization languages such as YAML or JSON, TOML restricts itself to the needs of configuration files. It supports only the data types commonly required for configuration — strings, integers, floats, booleans, arrays, tables, and date-time types — and deliberately avoids more complex constructs like schemas, inheritance, or executable logic. This minimalism reduces the cognitive burden on both humans writing TOML files and developers implementing parsers. By keeping the feature set small and well-defined, TOML avoids the ambiguity and complexity that plague more feature-rich formats, making it a reliable and predictable choice for its intended use case.
+
+## 2. Easy to Read Due to Obvious Semantics
+
+The second principle emphasizes *obvious semantics* — the meaning of a TOML document should be immediately clear to a human reader without requiring reference to a specification. This is reflected in TOML's straightforward syntax: key/value pairs use a simple `key = value` notation, tables are introduced with recognizable `[table]` headers, and arrays of tables use `[[array]]` double-bracket syntax. There are no sigils with overloaded meanings, no significant whitespace rules beyond basic formatting, and no implicit type coercion. What you see on the page is what you get. This commitment to readability ensures that configuration files remain approachable even for users who are not deeply familiar with the format, lowering the barrier to entry and reducing the likelihood of misconfiguration.
+
+## 3. Unambiguous Mapping to a Hash Table
+
+TOML is designed to map *unambiguously* to a hash table (or dictionary, map, or object, depending on the programming language). This principle ensures that every valid TOML document has exactly one valid interpretation as a data structure. There is no room for parsers to make subjective decisions about how to represent the data — the mapping is deterministic. This is a critical property for a configuration format, as it guarantees that different implementations in different languages will all produce equivalent data structures from the same TOML input. The specification reinforces this by explicitly forbidding ambiguous constructs, such as defining the same key or table more than once. Combined with the goal of being easy to parse across a wide variety of languages, this principle makes TOML a trustworthy interchange format that developers can rely on for consistent behavior.
+
+## Conclusion
+
+These three principles — minimalism, obvious semantics, and unambiguous hash table mapping — work in concert to make TOML a configuration format that is simple to write, easy to read, and reliable to parse. They represent a deliberate design philosophy that prioritizes clarity and consistency over expressive power, and this restraint is precisely what makes TOML effective for its intended purpose.


### PR DESCRIPTION
## Summary

This PR adds a concise analysis of the three core design principles of TOML as stated in the official specification document (`toml.md`).

## Changes

- Created `docs/design_principles_analysis.md` containing an analysis of TOML's three design principles:
  1. **Minimal Configuration File Format** — TOML restricts itself to configuration needs, avoiding complex constructs like schemas or executable logic.
  2. **Easy to Read Due to Obvious Semantics** — The syntax is designed so that the meaning of a document is immediately clear to a human reader without requiring reference to a specification.
  3. **Unambiguous Mapping to a Hash Table** — Every valid TOML document has exactly one valid interpretation as a data structure, ensuring consistent behavior across implementations.

The analysis explains each principle in plain language and discusses how they work together to make TOML an effective configuration format.